### PR TITLE
Improve chromedriver version check and automatically install correct chromedriver version

### DIFF
--- a/IMDbTraktSyncer/checkChromedriver.py
+++ b/IMDbTraktSyncer/checkChromedriver.py
@@ -1,17 +1,91 @@
 import feedparser
 import subprocess
 import pkg_resources
+import platform
+
+def get_chrome_version():
+    system = platform.system()
+    if system == 'Windows':
+        from winreg import ConnectRegistry, HKEY_CURRENT_USER, OpenKey, QueryValueEx
+
+        try:
+            registry = ConnectRegistry(None, HKEY_CURRENT_USER)
+            key = OpenKey(registry, r'Software\Google\Chrome\BLBeacon')
+            version, _ = QueryValueEx(key, 'version')
+            return version.split('.')[0]
+        except:
+            return None
+
+    elif system == 'Darwin':
+        try:
+            plist_path = '/Applications/Google Chrome.app/Contents/Info.plist'
+            with open(plist_path, 'rb') as plist_file:
+                plist_content = plist_file.read().decode('utf-8')
+            version_start = plist_content.index('<key>CFBundleShortVersionString</key>') + 38
+            version_end = plist_content.index('</string>', version_start)
+            return plist_content[version_start:version_end].split('.')[0]
+        except:
+            return None
+
+    elif system == 'Linux':
+        try:
+            process = subprocess.run(['google-chrome', '--version'], capture_output=True, text=True)
+            version = process.stdout.strip().split(' ')[2].split('.')[0]
+            return version
+        except:
+            return None
+
+    return None
+
+def install_chromedriver(version):
+    # Install the chromedriver-py package using pip
+    subprocess.run(['pip', 'install', f'chromedriver-py=={version}'])
 
 # Check if chromedriver-py is already installed
 try:
-    pkg_resources.get_distribution('chromedriver-py')
-#    print("chromedriver-py is already installed. Skipping installation.")
+    dist = pkg_resources.get_distribution('chromedriver-py')
+    installed_version = dist.version.split('.')[0]  # Retrieve only the prefix
+    chrome_version = get_chrome_version()
+
+    if chrome_version and installed_version != chrome_version:
+        # Make a request to the RSS feed
+        feed = feedparser.parse('https://pypi.org/rss/project/chromedriver-py/releases.xml')
+
+        # Find the corresponding chromedriver-py version
+        matching_version = None
+        for entry in feed.entries:
+            title = entry.title
+            if title.startswith(chrome_version):
+                matching_version = title.split()[-1]
+                break
+
+        if matching_version:
+            # Install the corresponding chromedriver-py version
+            install_chromedriver(matching_version)
+        else:
+            print(f"No matching chromedriver-py version found for Chrome {chrome_version}")
+    else:
+        # print("chromedriver-py is already installed with the correct version.")
+        pass
 except pkg_resources.DistributionNotFound:
-    # Make a request to the RSS feed
-    feed = feedparser.parse('https://pypi.org/rss/project/chromedriver-py/releases.xml')
+    chrome_version = get_chrome_version()
 
-    # Get the second latest release version
-    version = feed.entries[1].title.split()[-1]
+    if chrome_version:
+        # Make a request to the RSS feed
+        feed = feedparser.parse('https://pypi.org/rss/project/chromedriver-py/releases.xml')
 
-    # Install the chromedriver-py package using pip
-    subprocess.run(['pip', 'install', f'chromedriver-py=={version}'])
+        # Find the corresponding chromedriver-py version
+        matching_version = None
+        for entry in feed.entries:
+            title = entry.title
+            if title.startswith(chrome_version):
+                matching_version = title.split()[-1]
+                break
+
+        if matching_version:
+            # Install the corresponding chromedriver-py version
+            install_chromedriver(matching_version)
+        else:
+            print(f"No matching chromedriver-py version found for Chrome {chrome_version}")
+    else:
+        print("Failed to retrieve Chrome version.")

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.1.1'
+VERSION = '1.1.2'
 DESCRIPTION = 'This python script will sync user ratings for Movies and TV Shows both ways between Trakt and IMDb.'
 
 # Setting up


### PR DESCRIPTION
- Modify `checkChromedrivery.py` to ensure that the appropriate version of `chromedriver-py` is installed based on the current installed Chrome version, and it handles different operating systems to retrieve the Chrome version accordingly. 

_Tested and working on Windows. Untested on Linux and MacOS. If this update causes you issues please open an issue and describe the error you are receiving and your operating system._