### PR TITLE
Add chromedriver fallback install method

### DIFF
--- a/IMDbTraktSyncer/checkChromedriver.py
+++ b/IMDbTraktSyncer/checkChromedriver.py
@@ -41,6 +41,15 @@ def install_chromedriver(version):
     # Install the chromedriver-py package using pip
     subprocess.run(['pip', 'install', f'chromedriver-py=={version}'])
 
+def install_chromedriver_fallback_method():
+    print("Using install chromedriver-py fallback method")
+    # Install the chromedriver-py package using pip
+    feed = feedparser.parse('https://pypi.org/rss/project/chromedriver-py/releases.xml')
+    # Get the second latest release version
+    version = feed.entries[1].title.split()[-1]
+    # Install the chromedriver-py package using pip
+    subprocess.run(['pip', 'install', f'chromedriver-py=={version}'])
+
 # Check if chromedriver-py is already installed
 try:
     dist = pkg_resources.get_distribution('chromedriver-py')
@@ -87,5 +96,7 @@ except pkg_resources.DistributionNotFound:
             install_chromedriver(matching_version)
         else:
             print(f"No matching chromedriver-py version found for Chrome {chrome_version}")
+            install_chromedriver_fallback_method()
     else:
         print("Failed to retrieve Chrome version.")
+        install_chromedriver_fallback_method()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.1.2'
+VERSION = '1.1.3'
 DESCRIPTION = 'This python script will sync user ratings for Movies and TV Shows both ways between Trakt and IMDb.'
 
 # Setting up


### PR DESCRIPTION
- Modify code for checkChromedriver.py to use fallback install method for chromedriver-py when the script is unable to determine the Chrome version on the machine.