### PR TITLE
Fix for chromedriver version check syntax error + minor spelling changes

### DIFF
--- a/IMDBTraktSyncer/IMDBTraktSyncer.py
+++ b/IMDBTraktSyncer/IMDBTraktSyncer.py
@@ -185,7 +185,7 @@ def main():
                         print(f"Failed to add item ({item_count} of {num_items}): {item['Title']} ({item['Year']}) to Trakt Watchlist")
                         print("Error Response:", response.content, response.status_code)
 
-                print('Trakt Watchlist Items Set Successfully')
+                print('Setting IMDB Watchlist Items Complete')
             else:
                 print('No Trakt Watchlist Items To Set')
 

--- a/IMDBTraktSyncer/checkChromedriver.py
+++ b/IMDBTraktSyncer/checkChromedriver.py
@@ -40,7 +40,7 @@ def get_chrome_version():
 
 def install_chromedriver(version):
     # Install the chromedriver-py package using the Python interpreter
-    subprocess.run([sys.executable, '-m', 'pip', 'install', '--no-cache-dir' f'chromedriver-py=={version}'])
+    subprocess.run([sys.executable, '-m', 'pip', 'install', '--no-cache-dir', f'chromedriver-py=={version}'])
 
 def install_chromedriver_fallback_method():
     print("Using install chromedriver-py fallback method")
@@ -49,7 +49,7 @@ def install_chromedriver_fallback_method():
     # Get the second latest release version
     version = feed.entries[1].title.split()[-1]
     # Install the chromedriver-py package using pip
-    subprocess.run([sys.executable, '-m', 'pip', 'install', '--no-cache-dir' f'chromedriver-py=={version}'])
+    subprocess.run([sys.executable, '-m', 'pip', 'install', '--no-cache-dir', f'chromedriver-py=={version}'])
 
 # Check if chromedriver-py is already installed
 try:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.3.7'
+VERSION = '1.3.8'
 DESCRIPTION = 'This python script syncs user watchlist, ratings and comments for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up


### PR DESCRIPTION
- Fix for chromedriver version check syntax error. This was preventing the correct chromedriver version from being installed.
- Minor spelling changes