### PR TITLE
Fix for timeout error breaking script when rating some items on IMDB

### DIFF
--- a/IMDBTraktSyncer/IMDBTraktSyncer.py
+++ b/IMDBTraktSyncer/IMDBTraktSyncer.py
@@ -314,13 +314,13 @@ def main():
                 print(f'Rating {item["Type"]}: ({i} of {len(imdb_ratings_to_set)}) {item["Title"]}{year_str}: {item["Rating"]}/10 on IMDB')
                 driver.get(f'https://www.imdb.com/title/{item["IMDB_ID"]}/')
                 
-                # Wait until rate button is located and scroll to it
-                button = wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, '[data-testid="hero-rating-bar__user-rating"] button.ipc-btn')))
-                driver.execute_script("arguments[0].scrollIntoView(true);", button)
-
-                # click on "Rate" button and select rating option, then submit rating
-                button = wait.until(EC.element_to_be_clickable((By.CSS_SELECTOR, '[data-testid="hero-rating-bar__user-rating"] button.ipc-btn')))
                 try:
+                    # Wait until rate button is located and scroll to it
+                    button = wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, '[data-testid="hero-rating-bar__user-rating"] button.ipc-btn')))
+                    driver.execute_script("arguments[0].scrollIntoView(true);", button)
+
+                    # click on "Rate" button and select rating option, then submit rating
+                    button = wait.until(EC.element_to_be_clickable((By.CSS_SELECTOR, '[data-testid="hero-rating-bar__user-rating"] button.ipc-btn')))
                     element_rating_bar = button.find_element(By.CSS_SELECTOR, '[data-testid="hero-rating-bar__user-rating__unrated"]')
                     if element_rating_bar:
                         driver.execute_script("arguments[0].click();", button)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.4.0'
+VERSION = '1.4.1'
 DESCRIPTION = 'A python script that syncs user watchlist, ratings and comments for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up


### PR DESCRIPTION
### Bug Fixes:
- Fix for timeout error breaking script when rating some items on IMDB. https://github.com/RileyXX/IMDB-Trakt-Syncer/issues/46#issuecomment-1594097658

### Detailed Changes:
- Modified setting `IMDB ratings` in `IMDBTraktSyncer.py` so the entire code block is handled with error exceptions to avoid the script breaking when there are errors rating an item. (404 errors causing timeout exceptions etc).
- Modified getting `IMDB reviews` in `imdbData.py` so the entire code block is handled with error exceptions to avoid the script breaking if there are errors finding and clicking the reviews link.