### PR TITLE
Add error logging and error handling for IMDB requests

### DIFF
--- a/IMDBTraktSyncer/authTrakt.py
+++ b/IMDBTraktSyncer/authTrakt.py
@@ -1,5 +1,9 @@
 import requests
 import time
+try:
+    from IMDBTraktSyncer import errorLogger as EL
+except ImportError:
+    import errorLogger as EL
 
 def make_trakt_request(url, headers=None, params=None, payload=None, max_retries=3):
     retry_delay = 5  # seconds between retries
@@ -27,7 +31,9 @@ def make_trakt_request(url, headers=None, params=None, payload=None, max_retries
             print(f"Request failed with exception: {e}")
             return None
 
-    print("Max retry attempts reached with Trakt API, request failed.")
+    error_message = "Max retry attempts reached with Trakt API, request failed."
+    print(f"{error_message}")
+    EL.logger.error(error_message)
     return None
 
 def get_trakt_message(status_code):

--- a/IMDBTraktSyncer/checkChromedriver.py
+++ b/IMDBTraktSyncer/checkChromedriver.py
@@ -3,6 +3,10 @@ import subprocess
 import pkg_resources
 import platform
 import sys
+try:
+    from IMDBTraktSyncer import errorLogger as EL
+except ImportError:
+    import errorLogger as EL
 
 def get_chrome_version():
     system = platform.system()

--- a/IMDBTraktSyncer/errorLogger.py
+++ b/IMDBTraktSyncer/errorLogger.py
@@ -1,0 +1,41 @@
+import logging
+import traceback
+from logging.handlers import RotatingFileHandler
+
+class CustomFormatter(logging.Formatter):
+    def formatException(self, exc_info):
+        result = super().formatException(exc_info)
+        return f"{result}"
+
+    def format(self, record):
+        if record.exc_info:
+            # Save the original exc_info and set it to None
+            exc_info = record.exc_info
+            record.exc_info = None
+            # Format the log message without the traceback
+            message = super().format(record)
+            # Restore the original exc_info
+            record.exc_info = exc_info
+            # Add the traceback to the log message
+            traceback_message = self.formatException(record.exc_info)
+            return f"{'`' * 100}\n{message}\n{traceback_message}\n{'`' * 100}\n"
+        else:
+            message = super().format(record)
+            return f"{'`' * 100}\n{message}\n{'`' * 100}\n"
+
+# Set up the logging configuration
+log_file = 'log.txt'
+max_file_size = 1024 * 1024  # 1 MB
+backup_count = 0  # Set to 0 for only one log file
+
+# Create a rotating file handler
+handler = RotatingFileHandler(log_file, maxBytes=max_file_size, backupCount=backup_count)
+handler.setLevel(logging.ERROR)
+
+# Set the log format
+formatter = CustomFormatter('%(asctime)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+
+# Get the root logger and add the handler
+logger = logging.getLogger('')
+logger.addHandler(handler)

--- a/IMDBTraktSyncer/traktData.py
+++ b/IMDBTraktSyncer/traktData.py
@@ -5,8 +5,10 @@ import urllib.parse
 import datetime
 try:
     from IMDBTraktSyncer import errorHandling as EH
+    from IMDBTraktSyncer import errorLogger as EL
 except ImportError:
     import errorHandling as EH
+    import errorLogger as EL
 
 def getTraktData():
     # Process Trakt Ratings and Comments

--- a/IMDBTraktSyncer/verifyCredentials.py
+++ b/IMDBTraktSyncer/verifyCredentials.py
@@ -3,8 +3,10 @@ import json
 import datetime
 try:
     from IMDBTraktSyncer import authTrakt
+    from IMDBTraktSyncer import errorLogger as EL
 except ImportError:
     import authTrakt
+    import errorLogger as EL
 
 def prompt_get_credentials():
     # Define the file path
@@ -81,6 +83,8 @@ def prompt_sync_ratings():
             if sync_ratings_value is not None:
                 return sync_ratings_value
     except FileNotFoundError:
+        error_message = "File not found error"
+        EL.logger.error(error_message, exc_info=True)
         pass
 
     while True:
@@ -105,6 +109,8 @@ def prompt_sync_ratings():
         with open(file_path, 'r', encoding='utf-8') as file:
             credentials = json.load(file)
     except FileNotFoundError:
+        error_message = "File not found error"
+        EL.logger.error(error_message, exc_info=True)
         pass
 
     credentials['sync_ratings'] = sync_ratings_value
@@ -128,6 +134,8 @@ def prompt_sync_watchlist():
             if sync_watchlist_value is not None:
                 return sync_watchlist_value
     except FileNotFoundError:
+        error_message = "File not found error"
+        EL.logger.error(error_message, exc_info=True)
         pass
 
     while True:
@@ -152,6 +160,8 @@ def prompt_sync_watchlist():
         with open(file_path, 'r', encoding='utf-8') as file:
             credentials = json.load(file)
     except FileNotFoundError:
+        error_message = "File not found error"
+        EL.logger.error(error_message, exc_info=True)
         pass
 
     credentials['sync_watchlist'] = sync_watchlist_value
@@ -202,6 +212,8 @@ def prompt_sync_reviews():
             if sync_reviews_value is not None:
                 return sync_reviews_value
     except FileNotFoundError:
+        error_message = "File not found error"
+        EL.logger.error(error_message, exc_info=True)
         pass
 
     while True:
@@ -227,6 +239,8 @@ def prompt_sync_reviews():
         with open(file_path, 'r', encoding='utf-8') as file:
             credentials = json.load(file)
     except FileNotFoundError:
+        error_message = "File not found error"
+        EL.logger.error(error_message, exc_info=True)
         pass
 
     credentials['sync_reviews'] = sync_reviews_value
@@ -250,6 +264,8 @@ def prompt_remove_watched_from_watchlists():
             if remove_watched_from_watchlists_value is not None:
                 return remove_watched_from_watchlists_value
     except FileNotFoundError:
+        error_message = "File not found error"
+        EL.logger.error(error_message, exc_info=True)
         pass
 
     while True:
@@ -276,6 +292,8 @@ def prompt_remove_watched_from_watchlists():
         with open(file_path, 'r', encoding='utf-8') as file:
             credentials = json.load(file)
     except FileNotFoundError:
+        error_message = "File not found error"
+        EL.logger.error(error_message, exc_info=True)
         pass
 
     credentials['remove_watched_from_watchlists'] = remove_watched_from_watchlists_value

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.4.2'
+VERSION = '1.5.0'
 DESCRIPTION = 'A python script that syncs user watchlist, ratings and comments for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up


### PR DESCRIPTION
- Added support for error logging in `log.txt` for more thorough troubleshooting.
- IMDB requests are now properly handled by detecting errors and using retries where necessary (rate limit exceeded, server overloaded etc). Retryable status codes: `408, 425, 429, 500, 502, 503, 504`
- Improved rating, adding or removing items on IMDB. The script now properly waits until certain elements have loaded before executing the script.