### PR TITLE
Fix for IMDB actions failing when reference view setting is enabled on IMDB

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.5.5'
+VERSION = '1.6.0'
 DESCRIPTION = 'A python script that syncs user watchlist, ratings and comments for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up


### PR DESCRIPTION
- Fix for IMDB actions failing when `Show reference view with full cast and crew (advanced view)` setting is enabled on IMDB https://www.imdb.com/preferences/general. Actions that were effected: setting IMDB ratings, adding items to IMDB watchlist, removing items from IMDB watchlist.
- Fix for https://github.com/RileyXX/IMDB-Trakt-Syncer/issues/56
- Potential fix for https://github.com/RileyXX/IMDB-Trakt-Syncer/issues/46