### PR TITLE
Add support for updating ratings with most recent rating

### DIFF
--- a/IMDBTraktSyncer/imdbData.py
+++ b/IMDBTraktSyncer/imdbData.py
@@ -2,6 +2,7 @@ import os
 import time
 import csv
 import requests
+from datetime import datetime
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
@@ -53,6 +54,9 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
                     title = row[5]
                     year = row[10]
                     imdb_id = row[1]
+                    date_added = row[2]
+                    # Convert date format
+                    date_added = datetime.strptime(date_added, '%Y-%m-%d').strftime('%Y-%m-%dT%H:%M:%S.000Z')
                     if "tvSeries" in row[7] or "tvMiniSeries" in row[7]:
                         media_type = "show"
                     elif "tvEpisode" in row[7]:
@@ -61,7 +65,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
                         media_type = "movie"
                     else:
                         media_type = "unknown"
-                    imdb_watchlist.append({'Title': title, 'Year': year, 'IMDB_ID': imdb_id, 'Type': media_type})
+                    imdb_watchlist.append({'Title': title, 'Year': year, 'IMDB_ID': imdb_id, 'Date_Added': date_added, 'Type': media_type})
         except FileNotFoundError:
             error_message = "Ratings file not found"
             print(f"{error_message}")
@@ -108,6 +112,9 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
                     year = row[8]
                     rating = row[1]
                     imdb_id = row[0]
+                    date_added = row[2]
+                    # Convert date format
+                    date_added = datetime.strptime(date_added, '%Y-%m-%d').strftime('%Y-%m-%dT%H:%M:%S.000Z')
                     if "tvSeries" in row[5] or "tvMiniSeries" in row[5]:
                         media_type = "show"
                     elif "tvEpisode" in row[5]:
@@ -116,7 +123,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
                         media_type = "movie"
                     else:
                         media_type = "unknown"
-                    imdb_ratings.append({'Title': title, 'Year': year, 'Rating': rating, 'IMDB_ID': imdb_id, 'Type': media_type})
+                    imdb_ratings.append({'Title': title, 'Year': year, 'Rating': int(rating), 'IMDB_ID': imdb_id, 'Date_Added': date_added, 'Type': media_type})
         except FileNotFoundError:
             print('Ratings file not found')
             

--- a/IMDBTraktSyncer/traktData.py
+++ b/IMDBTraktSyncer/traktData.py
@@ -30,12 +30,12 @@ def getTraktData():
             movie = item.get('movie')
             imdb_movie_id = movie.get('ids', {}).get('imdb')
             trakt_movie_id = movie.get('ids', {}).get('trakt')
-            trakt_watchlist.append({'Title': movie.get('title'), 'Year': movie.get('year'), 'IMDB_ID': imdb_movie_id, 'TraktID': trakt_movie_id, 'Type': 'movie'})
+            trakt_watchlist.append({'Title': movie.get('title'), 'Year': movie.get('year'), 'IMDB_ID': imdb_movie_id, 'TraktID': trakt_movie_id, 'Date_Added': item.get('listed_at'), 'Type': 'movie'})
         elif item['type'] == 'show':
             show = item.get('show')
             imdb_show_id = show.get('ids', {}).get('imdb')
             trakt_show_id = show.get('ids', {}).get('trakt')
-            trakt_watchlist.append({'Title': show.get('title'), 'Year': show.get('year'), 'IMDB_ID': imdb_show_id, 'TraktID': trakt_show_id, 'Type': 'show'})
+            trakt_watchlist.append({'Title': show.get('title'), 'Year': show.get('year'), 'IMDB_ID': imdb_show_id, 'TraktID': trakt_show_id, 'Date_Added': item.get('listed_at'), 'Type': 'show'})
         elif item['type'] == 'episode':
             show = item.get('show')
             show_title = show.get('title')
@@ -43,7 +43,7 @@ def getTraktData():
             imdb_episode_id = episode.get('ids', {}).get('imdb')
             trakt_episode_id = episode.get('ids', {}).get('trakt')
             episode_title = f'{show_title}: {episode.get("title")}'
-            trakt_watchlist.append({'Title': episode_title, 'Year': episode.get('year'), 'IMDB_ID': imdb_episode_id, 'TraktID': trakt_episode_id, 'Type': 'episode'})
+            trakt_watchlist.append({'Title': episode_title, 'Year': episode.get('year'), 'IMDB_ID': imdb_episode_id, 'TraktID': trakt_episode_id, 'Date_Added': item.get('listed_at'), 'Type': 'episode'})
     
     # Get Trakt Ratings
     response = EH.make_trakt_request(f'https://api.trakt.tv/users/{encoded_username}/ratings?sort=newest')
@@ -57,18 +57,18 @@ def getTraktData():
         if item['type'] == 'movie':
             movie = item.get('movie')
             movie_id = movie.get('ids', {}).get('imdb')
-            movie_ratings.append({'Title': movie.get('title'), 'Year': movie.get('year'), 'Rating': item.get('rating'), 'IMDB_ID': movie_id, 'Type': 'movie'})
+            movie_ratings.append({'Title': movie.get('title'), 'Year': movie.get('year'), 'Rating': item.get('rating'), 'IMDB_ID': movie_id, 'Date_Added': item.get('rated_at'), 'Type': 'movie'})
         elif item['type'] == 'show':
             show = item.get('show')
             show_id = show.get('ids', {}).get('imdb')
-            show_ratings.append({'Title': show.get('title'), 'Year': show.get('year'), 'Rating': item.get('rating'), 'IMDB_ID': show_id, 'Type': 'show'})
+            show_ratings.append({'Title': show.get('title'), 'Year': show.get('year'), 'Rating': item.get('rating'), 'IMDB_ID': show_id, 'Date_Added': item.get('rated_at'), 'Type': 'show'})
         elif item['type'] == 'episode':
             show = item.get('show')
             show_title = show.get('title')
             episode = item.get('episode')
             episode_id = episode.get('ids', {}).get('imdb')
             episode_title = f'{show_title}: {episode.get("title")}'
-            episode_ratings.append({'Title': episode_title, 'Year': episode.get('year'), 'Rating': item.get('rating'), 'IMDB_ID': episode_id, 'Type': 'episode'})
+            episode_ratings.append({'Title': episode_title, 'Year': episode.get('year'), 'Rating': item.get('rating'), 'IMDB_ID': episode_id, 'Date_Added': item.get('rated_at'), 'Type': 'episode'})
 
     trakt_ratings = movie_ratings + show_ratings + episode_ratings
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.6.0'
+VERSION = '1.7.0'
 DESCRIPTION = 'A python script that syncs user watchlist, ratings and comments for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up


### PR DESCRIPTION
- Added support for updating ratings with most recent rating.

**Note:** For items rated on the same day but with different ratings, the Trakt rating will take priority. This is due to and IMDB limitation. The IMDB ratings csv data only includes the rated date in Y-M-D format without a time.