### PR TITLE
Modify updating ratings logic so that ratings made on the same day are not overwritten

### DIFF
--- a/IMDBTraktSyncer/IMDBTraktSyncer.py
+++ b/IMDBTraktSyncer/IMDBTraktSyncer.py
@@ -153,11 +153,13 @@ def main():
                     imdb_date_added = datetime.fromisoformat(imdb_rating['Date_Added'])
                     trakt_date_added = datetime.fromisoformat(trakt_rating['Date_Added'])
                     
-                    # If IMDB rating is more recent, add the Trakt rating to the update list, and vice versa
-                    if imdb_date_added > trakt_date_added:
-                        trakt_ratings_to_update.append(imdb_rating)
-                    else:
-                        imdb_ratings_to_update.append(trakt_rating)
+                    # Check if ratings were added on different days
+                    if (imdb_date_added.year, imdb_date_added.month, imdb_date_added.day) != (trakt_date_added.year, trakt_date_added.month, trakt_date_added.day):
+                        # If IMDB rating is more recent, add the Trakt rating to the update list, and vice versa
+                        if imdb_date_added > trakt_date_added:
+                            trakt_ratings_to_update.append(imdb_rating)
+                        else:
+                            imdb_ratings_to_update.append(trakt_rating)
 
         # Update ratings_to_set
         imdb_ratings_to_set.extend(imdb_ratings_to_update)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.7.0'
+VERSION = '1.7.1'
 DESCRIPTION = 'A python script that syncs user watchlist, ratings and comments for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up


### PR DESCRIPTION
- Modify updating ratings logic so that ratings changed on the same day are not overwritten. 

**Note:** Originally in [1.7.0 release](https://github.com/RileyXX/IMDB-Trakt-Syncer/releases/tag/v1.7.0) the Trakt rating would take priority for ratings changed on the same day. This was changed in 1.7.1 in order to keep the original functionality where ratings are not overwritten. This will avoid situations where the user updates a rating on IMDB and then it is overwritten with an older Trakt rating on next sync. 

This problem originates from an IMDB limitation. The ratings csv data IMDB provides only includes the rated date in Y-M-D format without a time. 