### PR TITLE
Increase performance for Trakt requests + add support for additional IMDB media types

### DIFF
--- a/IMDBTraktSyncer/IMDBTraktSyncer.py
+++ b/IMDBTraktSyncer/IMDBTraktSyncer.py
@@ -231,13 +231,16 @@ def main():
                                 "imdb": imdb_id
                             }
                         })
+                    else:
+                        data = None
 
-                    response = EH.make_trakt_request(url, payload=data)
-                    
-                    if response is None:
-                        error_message = f"Failed to add item ({item_count} of {num_items}): {item['Title']} ({item['Year']}) to Trakt Watchlist"
-                        print(f"   - {error_message}")
-                        EL.logger.error(error_message)
+                    if data:
+                        response = EH.make_trakt_request(url, payload=data)
+                        
+                        if response is None:
+                            error_message = f"Failed to add item ({item_count} of {num_items}): {item['Title']} ({item['Year']}) to Trakt Watchlist"
+                            print(f"   - {error_message}")
+                            EL.logger.error(error_message)
 
                 print('Setting Trakt Watchlist Items Complete')
             else:
@@ -364,14 +367,17 @@ def main():
                             }]
                         }
                         print(f" - Rating episode ({item_count} of {num_items}): {item['Title']} ({item['Year']}): {item['Rating']}/10 on Trakt")
+                    else:
+                        data = None
+                    
+                    if data:
+                        # Make the API call to rate the item
+                        response = EH.make_trakt_request(rate_url, payload=data)
 
-                    # Make the API call to rate the item
-                    response = EH.make_trakt_request(rate_url, payload=data)
-
-                    if response is None:
-                        error_message = f"Failed rating {item['Type']} ({item_count} of {num_items}): {item['Title']} ({item['Year']}): {item['Rating']}/10 on Trakt"
-                        print(f"   - {error_message}")
-                        EL.logger.error(error_message)
+                        if response is None:
+                            error_message = f"Failed rating {item['Type']} ({item_count} of {num_items}): {item['Title']} ({item['Year']}): {item['Rating']}/10 on Trakt"
+                            print(f"   - {error_message}")
+                            EL.logger.error(error_message)
 
                 print('Setting Trakt Ratings Complete')
             else:
@@ -487,13 +493,16 @@ def main():
                                     "imdb": episode_id
                                 }
                             }
+                        else:
+                            data = None
                         
-                        response = EH.make_trakt_request(url, payload=data)
-                        
-                        if response is None:
-                            error_message = f"Failed to submit comment ({item_count} of {num_items}): {review['Title']} ({review['Year']}) on Trakt"
-                            print(f"   - {error_message}")
-                            EL.logger.error(error_message)
+                        if data:
+                            response = EH.make_trakt_request(url, payload=data)
+                            
+                            if response is None:
+                                error_message = f"Failed to submit comment ({item_count} of {num_items}): {review['Title']} ({review['Year']}) on Trakt"
+                                print(f"   - {error_message}")
+                                EL.logger.error(error_message)
 
                     print('Trakt Reviews Set Successfully')
                 else:
@@ -600,14 +609,17 @@ def main():
                             }]
                         }
                         print(f" - Removing episode ({item_count} of {num_items}): {item['Title']} ({item['Year']}) from Trakt Watchlist")
+                    else:
+                        data = None
 
-                    # Make the API call to remove the item from the watchlist
-                    response = EH.make_trakt_request(remove_url, payload=data)
+                    if data:
+                        # Make the API call to remove the item from the watchlist
+                        response = EH.make_trakt_request(remove_url, payload=data)
 
-                    if response is None:
-                        error_message = f"Failed removing {item['Type']} ({item_count} of {num_items}): {item['Title']} ({item['Year']}) from Trakt Watchlist"
-                        print(f"   - {error_message}")
-                        EL.logger.error(error_message)
+                        if response is None:
+                            error_message = f"Failed removing {item['Type']} ({item_count} of {num_items}): {item['Title']} ({item['Year']}) from Trakt Watchlist"
+                            print(f"   - {error_message}")
+                            EL.logger.error(error_message)
 
                 print('Removing Watched Items From Trakt Watchlist Complete')
             else:

--- a/IMDBTraktSyncer/errorHandling.py
+++ b/IMDBTraktSyncer/errorHandling.py
@@ -32,7 +32,7 @@ def report_error(error_message):
     print(f"Submit the error here: {github_issue_url}")
     print("-" * 50)
 
-def make_trakt_request(url, headers=None, params=None, payload=None, max_retries=3):
+def make_trakt_request(url, headers=None, params=None, payload=None, max_retries=5):
     if headers is None:
         headers = {
             'Content-Type': 'application/json',
@@ -41,7 +41,7 @@ def make_trakt_request(url, headers=None, params=None, payload=None, max_retries
             'Authorization': f'Bearer {VC.trakt_access_token}'
         }
 
-    retry_delay = 5  # seconds between retries
+    retry_delay = 1  # seconds between retries
     retry_attempts = 0
 
     while retry_attempts < max_retries:

--- a/IMDBTraktSyncer/imdbData.py
+++ b/IMDBTraktSyncer/imdbData.py
@@ -61,7 +61,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
                         media_type = "show"
                     elif "tvEpisode" in row[7]:
                         media_type = "episode"
-                    elif "movie" in row[7]:
+                    elif "movie" in row[7] or "tvSpecial" in row[7] or "tvMovie" in row[7] or "tvShort" in row[7] or "video" in row[7]:
                         media_type = "movie"
                     else:
                         media_type = "unknown"
@@ -119,7 +119,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
                         media_type = "show"
                     elif "tvEpisode" in row[5]:
                         media_type = "episode"
-                    elif "movie" in row[5]:
+                    elif "movie" in row[5] or "tvSpecial" in row[5] or "tvMovie" in row[5] or "tvShort" in row[5] or "video" in row[5]:
                         media_type = "movie"
                     else:
                         media_type = "unknown"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.7.1'
+VERSION = '1.7.2'
 DESCRIPTION = 'A python script that syncs user watchlist, ratings and comments for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up


### PR DESCRIPTION
- Increase performance for Trakt requests (reduced initial retry wait time to 1 second and extended max retries to 5)
- Add support for additional IMDB media types `tvSpecial`, `tvMovie,` `tvShort` & `video`.
- Potential fix for https://github.com/RileyXX/IMDB-Trakt-Syncer/issues/61