### PR TITLE
Modify chromedriver check fallback method

### DIFF
--- a/IMDBTraktSyncer/authTrakt.py
+++ b/IMDBTraktSyncer/authTrakt.py
@@ -5,8 +5,8 @@ try:
 except ImportError:
     import errorLogger as EL
 
-def make_trakt_request(url, headers=None, params=None, payload=None, max_retries=3):
-    retry_delay = 5  # seconds between retries
+def make_trakt_request(url, headers=None, params=None, payload=None, max_retries=5):
+    retry_delay = 1  # seconds between retries
     retry_attempts = 0
 
     while retry_attempts < max_retries:

--- a/IMDBTraktSyncer/checkChromedriver.py
+++ b/IMDBTraktSyncer/checkChromedriver.py
@@ -50,7 +50,7 @@ def install_chromedriver_fallback_method():
     print("Using install chromedriver-py fallback method")
     # Install the chromedriver-py package using the Python interpreter
     feed = feedparser.parse('https://pypi.org/rss/project/chromedriver-py/releases.xml')
-    # Get the second latest release version
+    # Get the latest release version
     version = feed.entries[0].title.split()[-1]
     # Install the chromedriver-py package using pip
     subprocess.run([sys.executable, '-m', 'pip', 'install', '--no-cache-dir', f'chromedriver-py=={version}'])

--- a/IMDBTraktSyncer/checkChromedriver.py
+++ b/IMDBTraktSyncer/checkChromedriver.py
@@ -51,7 +51,7 @@ def install_chromedriver_fallback_method():
     # Install the chromedriver-py package using the Python interpreter
     feed = feedparser.parse('https://pypi.org/rss/project/chromedriver-py/releases.xml')
     # Get the second latest release version
-    version = feed.entries[1].title.split()[-1]
+    version = feed.entries[0].title.split()[-1]
     # Install the chromedriver-py package using pip
     subprocess.run([sys.executable, '-m', 'pip', 'install', '--no-cache-dir', f'chromedriver-py=={version}'])
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.7.3'
+VERSION = '1.7.4'
 DESCRIPTION = 'A python script that syncs user watchlist, ratings and comments for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.7.2'
+VERSION = '1.7.3'
 DESCRIPTION = 'A python script that syncs user watchlist, ratings and comments for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up


### PR DESCRIPTION
Modify chromedriver check fallback method to get the latest release instead of the second latest release. This is due to a change in the [chromedriver api](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints) and as a result the [chromedriver-py releases](https://pypi.org/project/chromedriver-py/#history) have changed. 