### PR TITLE
Potential fix for "Invalid isoformat" error on older python versions

### DIFF
--- a/IMDBTraktSyncer/IMDBTraktSyncer.py
+++ b/IMDBTraktSyncer/IMDBTraktSyncer.py
@@ -2,7 +2,7 @@ import os
 import json
 import requests
 import time
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
@@ -150,8 +150,8 @@ def main():
             if imdb_id in trakt_ratings_dict:
                 trakt_rating = trakt_ratings_dict[imdb_id]
                 if imdb_rating['Rating'] != trakt_rating['Rating']:
-                    imdb_date_added = datetime.fromisoformat(imdb_rating['Date_Added'])
-                    trakt_date_added = datetime.fromisoformat(trakt_rating['Date_Added'])
+                    imdb_date_added = datetime.fromisoformat(imdb_rating['Date_Added'].replace('Z', '')).replace(tzinfo=timezone.utc)
+                    trakt_date_added = datetime.fromisoformat(trakt_rating['Date_Added'].replace('Z', '')).replace(tzinfo=timezone.utc)
                     
                     # Check if ratings were added on different days
                     if (imdb_date_added.year, imdb_date_added.month, imdb_date_added.day) != (trakt_date_added.year, trakt_date_added.month, trakt_date_added.day):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.8.1'
+VERSION = '1.8.2'
 DESCRIPTION = 'A python script that syncs user watchlist, ratings and comments for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up


### PR DESCRIPTION
Pull request attempts to fix an issue for older Python versions where date formats with a trailing `Z` (timezone) are not supported.

Potential fix for https://github.com/RileyXX/IMDB-Trakt-Syncer/issues/66.

