### PR TITLE
Fix for improper chromedriver shutdown

### DIFF
--- a/IMDBTraktSyncer/IMDBTraktSyncer.py
+++ b/IMDBTraktSyncer/IMDBTraktSyncer.py
@@ -699,6 +699,7 @@ def main():
         
         #Close web driver
         print("Closing webdriver...")
+        driver.close()
         driver.quit()
         service.stop()
     
@@ -709,6 +710,7 @@ def main():
         
         # Close the driver and stop the service if they were initialized
         if 'driver' in locals() and driver is not None:
+            driver.close()
             driver.quit()
         if 'service' in locals() and service is not None:
             service.stop()

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.8.4'
-DESCRIPTION = 'A python script that syncs user watchlist, ratings and comments for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
+VERSION = '1.8.5'
+DESCRIPTION = 'A python script that syncs user watchlist, ratings and reviews for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up
 setup(


### PR DESCRIPTION
Fix for a bug which would cause chrome instances to not shutdown fully. This would occasionally leave some chrome processes to linger after the script completes. 

By invoking `driver.close()` before `driver.quit()` ensures that the headless chrome window(s) are closed properly prior to ending the chrome processes.