### PR TITLE
Fix for missing package requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.8.5'
+VERSION = '1.8.6'
 DESCRIPTION = 'A python script that syncs user watchlist, ratings and reviews for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     url="https://github.com/RileyXX/IMDB-Trakt-Syncer",
     packages=find_packages(),
-    install_requires=['requests', 'feedparser', 'selenium'],
+    install_requires=['requests', 'feedparser', 'selenium', 'setuptools'],
     keywords=['python', 'video', 'trakt', 'imdb', 'ratings', 'sync', 'movies', 'tv shows'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Fix for https://github.com/RileyXX/IMDB-Trakt-Syncer/issues/79. This pull request introduces a necessary addition to the `setup.py` file by including the `setuptools` package requirement. This modification is crucial to enable the import of `pkg_resources` in `checkChromedriver.py`. Previously, users who did not have `setuptools` installed would encounter script failures, and this update ensures a smoother experience for all users.