### PR TITLE
Minor change when prompting for IMDB username

### DIFF
--- a/IMDBTraktSyncer/verifyCredentials.py
+++ b/IMDBTraktSyncer/verifyCredentials.py
@@ -57,8 +57,12 @@ def prompt_get_credentials():
 
     # Check if any of the values are "empty" and prompt the user to enter them
     for key in values.keys():
-        if values[key] == "empty" and (key != "trakt_access_token" and key != "trakt_refresh_token"):
-            values[key] = input(f"Please enter a value for {key}: ").strip()
+        if values[key] == "empty" and key not in ["trakt_access_token", "trakt_refresh_token"]:
+            if key == "imdb_username":
+                prompt_message = f"Please enter a value for {key} (email or phone number): "
+            else:
+                prompt_message = f"Please enter a value for {key}: "
+            values[key] = input(prompt_message).strip()
             with open(file_path, 'w', encoding='utf-8') as f:
                 json.dump(values, f)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '1.9.2'
+VERSION = '1.9.3'
 DESCRIPTION = 'A python script that syncs user watchlist, ratings and reviews for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up


### PR DESCRIPTION
- Minor text change when prompting the user for `imdb_username`. This field should be the users `email` or `phone number` used for logging into IMDB. 
- This change should help users avoid accidently filling in the wrong info for this field as mentioned in https://github.com/RileyXX/IMDB-Trakt-Syncer/issues/2#issuecomment-1946046445.