### PR TITLE
Minor improvements for requests 429 rate limit error handling

### DIFF
--- a/IMDBTraktSyncer/errorHandling.py
+++ b/IMDBTraktSyncer/errorHandling.py
@@ -76,11 +76,12 @@ def make_trakt_request(url, headers=None, params=None, payload=None, max_retries
 
                 # Respect the 'Retry-After' header if provided, otherwise use default delay
                 retry_after = int(response.headers.get('Retry-After', retry_delay))
-                remaining_time = total_wait_time - sum(retry_delay * (2 ** i) for i in range(retry_attempts))
-                print(f"   - Server returned {response.status_code}. Retrying after {retry_after}s... "
-                      f"({retry_attempts}/{max_retries}) - Time remaining: {remaining_time}s")
-                EL.logger.warning(f"Server returned {response.status_code}. Retrying after {retry_after}s... "
-                                  f"({retry_attempts}/{max_retries}) - Time remaining: {remaining_time}s")
+                if response.status_code != 429:
+                    remaining_time = total_wait_time - sum(retry_delay * (2 ** i) for i in range(retry_attempts))
+                    print(f"   - Server returned {response.status_code}. Retrying after {retry_after}s... "
+                          f"({retry_attempts}/{max_retries}) - Time remaining: {remaining_time}s")
+                    EL.logger.warning(f"Server returned {response.status_code}. Retrying after {retry_after}s... "
+                                      f"({retry_attempts}/{max_retries}) - Time remaining: {remaining_time}s")
 
                 time.sleep(retry_after)  # Wait before retrying
                 retry_delay *= 2  # Apply exponential backoff for retries

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '3.0.1'
+VERSION = '3.0.2'
 DESCRIPTION = 'A python script that syncs user watchlist, ratings and reviews for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up


### PR DESCRIPTION
- Skip logging and printing 429 rate limit errors to allow faster processing and better readability