### PR TITLE
Removed chrome install requirement, added support for arguments and replaced webdriver-manager with selenium's new built in chromedriver manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Python script syncs user watchlist, ratings and reviews for Movies, TV Show
 The script is compatible with operating systems that support Python (v3.6 or later) and Chromedriver (Windows, Linux and Mac). If you're interested in syncing ratings between Trakt, Plex, IMDB, and TMDB, I recommend the following projects: [PlexTraktSync](https://github.com/Taxel/PlexTraktSync), [IMDB-Trakt-Syncer](https://github.com/RileyXX/IMDB-Trakt-Syncer), and [TMDB-Trakt-Syncer](https://github.com/RileyXX/TMDB-Trakt-Syncer). See below for my other [recommended projects](https://github.com/RileyXX/IMDB-Trakt-Syncer?tab=readme-ov-file#other-recommended-projects).
 
 ## Installation Instructions
-1. Install [Python](https://www.python.org/downloads/) (v3.6 or later) and [Google Chrome](https://www.google.com/chrome/). During Python installation, tick the box for adding Python to your PATH variable. _If these are already installed, you can skip this step. Please note this script does not affect Chrome in anyway, it is simply required in order for chromedriver to work._
+1. Install [Python](https://www.python.org/downloads/) (v3.6 or later). During Python installation, tick the box for adding Python to your PATH variable. _If Python is already installed, you can skip this step._
 2. Install the script by executing `python -m pip install IMDBTraktSyncer` in command line.
 3. Login to [Trakt](https://trakt.tv/oauth/applications) and create a new API application named `IMDBTraktSyncer`. In the "Redirect uri" field, enter `urn:ietf:wg:oauth:2.0:oob`, then save the application.
 4. Run the script by executing `IMDBTraktSyncer` in the command line.
@@ -15,36 +15,84 @@ The script is compatible with operating systems that support Python (v3.6 or lat
 ```
 python -m pip install IMDBTraktSyncer
 ```
-_Run in your operating system's native command line._
+_Run in your operating system's native command line interface._
 ## Running the Script:
 ```
 IMDBTraktSyncer
 ```
-_Run in your operating system's native command line._
+_Run in your operating system's native command line interface._
 ## Updating the Script:
 ```
 python -m pip install IMDBTraktSyncer --upgrade
 ```
-_Run in your operating system's native command line._
+_Run in your operating system's native command line interface._
 ## Uninstalling the Script:
 ```
-python -m pip uninstall IMDBTraktSyncer
+IMDBTraktSyncer --uninstall
 ```
-_Run in your operating system's native command line._
-
+_Clears cached browsers, drivers and error logs before uninstalling. Run in your operating system's native command line interface._
 ## Installing a Specific Version:
 ```
 python -m pip install IMDBTraktSyncer==VERSION_NUMBER
 ```
 _Replace `VERSION_NUMBER` with your [desired version](https://github.com/RileyXX/IMDB-Trakt-Syncer/releases) (e.g. 1.1.6) and run in your operating system's native command line._
+## Performing a Clean Uninstall:
+```
+IMDBTraktSyncer --clean-uninstall
+```
+_Clears all cached data, inluding user credentials, cached browsers and drivers before uninstalling. Run in your operating system's native command line interface._
+## Uninstall With Native Python Method:
+```
+python -m pip uninstall IMDBTraktSyncer
+```
+_Not recommended unless other uninstall methods failed. This method leaves behind any cached data such as user entered credentials, cached browsers, and drivers which can be deleted manually from your install directory. Run in your operating system's native command line._
+
+# Commands for IMDBTraktSyncer
+
+Below is a list of available commands for this package, along with a brief description of their functionality. You can copy and paste them directly into your terminal.
+
+## Available Commands
+
+| **Command**               | **Description**                                                                                       |
+|---------------------------|---------------------------------------------------------------------------------------------------|
+| `--clear-user-data`       | Clears user-entered credentials.                                                                  |
+| `--clear-cache`           | Clears cached browsers, drivers, and error logs.                                                 |
+| `--uninstall`             | Clears cached browsers, drivers, and error logs before uninstalling.                             |
+| `--clean-uninstall`       | Clears all cached data, including user credentials, cached browsers, and drivers before uninstalling. |
+| `--directory`             | Prints the package install directory.                                                            |
+
+## Usage Example
+
+Run the following commands as needed:
+
+```bash
+# To clear user data
+IMDBTraktSyncer --clear-user-data
+
+# To clear cache
+IMDBTraktSyncer --clear-cache
+
+# To uninstall
+IMDBTraktSyncer --uninstall
+
+# To perform a clean uninstall
+IMDBTraktSyncer --clean-uninstall
+
+# To get the installation directory
+IMDBTraktSyncer --directory
+
+# Use multiple commands at once
+IMDBTraktSyncer --clear-user-data --clear-cache
+```
 
 ## Alternative Manual Installation Method (without pip install)
-1. Install [Python](https://www.python.org/downloads/) (v3.6 or later) and [Google Chrome](https://www.google.com/chrome/). During Python installation, tick the box for adding Python to your PATH variable.  _If these are already installed, you can skip this step. Please note this script does not affect Chrome in anyway, it is simply required in order for chromedriver to work._
+1. Install [Python](https://www.python.org/downloads/) (v3.6 or later). During Python installation, tick the box for adding Python to your PATH variable.  _If Python is already installed, you can skip this step._
 2. Download the latest .zip from the [releases page](https://github.com/RileyXX/IMDB-Trakt-Syncer/releases) and extract it to the desired directory.
-3. Login to [Trakt](https://trakt.tv/oauth/applications) and create a new API application named `IMDBTraktSyncer`. In the "Redirect uri" field, enter `urn:ietf:wg:oauth:2.0:oob`, then save the application.
-4. Run `IMDBTraktSyncer.py` or open the terminal and navigate to the folder where `IMDBTraktSyncer.py` is located. Run `IMDBTraktSyncer.py` in the terminal.
-5. Follow the prompts during the first run. You will need to enter your Trakt `client ID` and `client secret` from step 3, as well as your IMDB `username` and `password`. Please note that these details are saved insecurely as `credentials.txt` in the same folder as the script. It is recommended to change your IMDB password to something unique beforehand.
-6. Setup is complete. The script will continue running and syncing your ratings. You can monitor its progress in the command line. See below for [setting up automation](https://github.com/RileyXX/IMDB-Trakt-Syncer#for-setting-up-automation-see-the-following-wiki-pages).
+3. Open your operating systems native command line interface, use it to navigate to the extracted folder and run `python -m pip install requirements.txt`.
+4. Login to [Trakt](https://trakt.tv/oauth/applications) and create a new API application named `IMDBTraktSyncer`. In the "Redirect uri" field, enter `urn:ietf:wg:oauth:2.0:oob`, then save the application.
+5. Run `IMDBTraktSyncer.py` or open the terminal and navigate to the folder where `IMDBTraktSyncer.py` is located. Run `IMDBTraktSyncer.py` in the terminal.
+6. Follow the prompts during the first run. You will need to enter your Trakt `client ID` and `client secret` from step 3, as well as your IMDB `username` and `password`. Please note that these details are saved insecurely as `credentials.txt` in the same folder as the script. It is recommended to change your IMDB password to something unique beforehand.
+7. Setup is complete. The script will continue running and syncing your ratings. You can monitor its progress in the command line. See below for [setting up automation](https://github.com/RileyXX/IMDB-Trakt-Syncer#for-setting-up-automation-see-the-following-wiki-pages).
 
 ## For Setting Up Automation See the Following Wiki Pages:
 - Setup Automation for:
@@ -54,9 +102,8 @@ _Replace `VERSION_NUMBER` with your [desired version](https://github.com/RileyXX
 - Python Script to Update all Packages with Pip (Windows, Linux, Mac, ChromeOS, etc.) [Link #1](https://github.com/RileyXX/IMDB-Trakt-Syncer/wiki/Python-Script-to-Update-all-Packages-with-Pip-\(Windows,-Linux,-Mac,-ChromeOS,-etc\))
 
 ## Troubleshooting, Known Issues, Workarounds & Future Outlook
-- If any of your details change (passwords, logins, API keys, etc.), simply open `credentials.txt`, modify your details, save it and then run the script again. Alternatively, delete `credentials.txt` to reset the script and it will prompt you to enter your new details on the next run.
+- If any of your details change (passwords, logins, API keys, etc.), simply run `IMDBTraktSyncer --clear-user-data` to reset your credentials. Alternatively, open `credentials.txt`, modify your details, save it and then run the script again. You can also simply delete `credentials.txt` to reset the script and it will prompt you to enter your new details on the next run.
 - If IMDB requires a captcha on login, and you see "Not signed in" appear in the script, the captcha is likely the cause. To fix this, navigate to the IMDB website in your browser (preferably Chrome) from the same computer. If you're already logged in, log out and log back in. It may ask you to fill in a captcha. Complete the captcha and finish logging in. After successfully logging in on your browser, run the script again, and it should work. You may need to repeat this step several times if the issue persists. Adding a captcha solver to the script is being considered but not currently implemented. [Issue #2](https://github.com/RileyXX/IMDB-Trakt-Syncer/issues/2)
-- If you see an error about having the incorrect version of Chromedriver, uninstall it by running the following command in the command line: `python -m pip uninstall chromedriver-py`. In your Chrome browser, go to Settings > About Chrome and check the prefix for your version (e.g., 112... or 111). If the prefix matches your Chrome version, navigate to the [chromedriver-py releases page](https://pypi.org/project/chromedriver-py/#history) and find the latest version that matches the prefix for your Chrome version. Copy the version number you need (e.g 113.0.5672.63), then run the following command in the command line: `python -m pip install chromedriver-py==VERSION_NUMBER`. Replace `VERSION_NUMBER` with the version you copied and press enter. This will install the correct version of Chromedriver. Run the script again, and it should work. [Issue #16](https://github.com/RileyXX/IMDB-Trakt-Syncer/issues/16)
 - Due to IMDB's lack of API and rating import ability, this script uses an unconventional method that mimics using a web browser to set ratings on IMDB. Therefore, there are many points of failure that could arise. The script will be updated as best as possible.
 
 ## Screenshot

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ _Clears cached browsers, drivers and error logs before uninstalling. Run in your
 ```
 python -m pip install IMDBTraktSyncer==VERSION_NUMBER
 ```
-_Replace `VERSION_NUMBER` with your [desired version](https://github.com/RileyXX/IMDB-Trakt-Syncer/releases) (e.g. 1.1.6) and run in your operating system's native command line._
+_Replace `VERSION_NUMBER` with your [desired version](https://github.com/RileyXX/IMDB-Trakt-Syncer/releases) (e.g. 1.1.6) and run in your operating system's native command line interface._
 ## Performing a Clean Uninstall:
 ```
 IMDBTraktSyncer --clean-uninstall
@@ -45,7 +45,7 @@ _Clears all cached data, inluding user credentials, cached browsers and drivers 
 ```
 python -m pip uninstall IMDBTraktSyncer
 ```
-_Not recommended unless other uninstall methods failed. This method leaves behind any cached data such as user entered credentials, cached browsers, and drivers which can be deleted manually from your install directory. Run in your operating system's native command line._
+_Not recommended unless other uninstall methods failed. This method leaves behind any cached data such as user entered credentials, cached browsers, and drivers which can be deleted manually from your install directory. Run in your operating system's native command line interface._
 
 # Commands for IMDBTraktSyncer
 

--- a/README.md
+++ b/README.md
@@ -15,27 +15,27 @@ The script is compatible with operating systems that support Python (v3.6 or lat
 ```
 python -m pip install IMDBTraktSyncer
 ```
-_Run in your operating system's native command line interface._
+_Run in your operating system's native command line._
 ## Running the Script:
 ```
 IMDBTraktSyncer
 ```
-_Run in your operating system's native command line interface._
+_Run in your operating system's native command line._
 ## Updating the Script:
 ```
 python -m pip install IMDBTraktSyncer --upgrade
 ```
-_Run in your operating system's native command line interface._
+_Run in your operating system's native command line._
 ## Uninstalling the Script:
 ```
 IMDBTraktSyncer --uninstall
 ```
-_Clears cached browsers, drivers and error logs before uninstalling. Run in your operating system's native command line interface._
+_Clears cached browsers, drivers and error logs before uninstalling. Run in your operating system's native command line._
 ## Installing a Specific Version:
 ```
 python -m pip install IMDBTraktSyncer==VERSION_NUMBER
 ```
-_Replace `VERSION_NUMBER` with your [desired version](https://github.com/RileyXX/IMDB-Trakt-Syncer/releases) (e.g. 1.1.6) and run in your operating system's native command line interface._
+_Replace `VERSION_NUMBER` with your [desired version](https://github.com/RileyXX/IMDB-Trakt-Syncer/releases) (e.g. 1.1.6) and run in your operating system's native command line._
 ## Performing a Clean Uninstall:
 ```
 IMDBTraktSyncer --clean-uninstall
@@ -45,7 +45,7 @@ _Clears all cached data, inluding user credentials, cached browsers and drivers 
 ```
 python -m pip uninstall IMDBTraktSyncer
 ```
-_Not recommended unless other uninstall methods failed. This method leaves behind any cached data such as user entered credentials, cached browsers, and drivers which can be deleted manually from your install directory. Run in your operating system's native command line interface._
+_Not recommended unless other uninstall methods failed. This method leaves behind any cached data such as user entered credentials, cached browsers, and drivers which can be deleted manually from your install directory. Run in your operating system's native command line._
 
 # Commands for IMDBTraktSyncer
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _Replace `VERSION_NUMBER` with your [desired version](https://github.com/RileyXX
 ```
 IMDBTraktSyncer --clean-uninstall
 ```
-_Clears all cached data, inluding user credentials, cached browsers and drivers before uninstalling. Run in your operating system's native command line interface._
+_Clears all cached data, inluding user credentials, cached browsers and drivers before uninstalling. Run in your operating system's native command line._
 ## Uninstall With Native Python Method:
 ```
 python -m pip uninstall IMDBTraktSyncer


### PR DESCRIPTION
## 1. Removed the Chrome install requirement:
The script now downloads and manages the portable "[Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/)" browser automatically in the install directory. This makes the package a whole more portable, bypasses issues with some Chrome installs, and allows for possible future implementations of docker support.

## 2. Removed webdriver-manager
The script now uses selenium's new built in tool `selenium manager` to download and manage chromedriver versions. Users upgrading to v3.1.0 can safely uninstall `webdriver-manager` using:
```
python -m pip uninstall webdriver-manager
```

## 2. Added arguments for easier package management:

### Available commands:
````bash
# To clear user data
IMDBTraktSyncer --clear-user-data

# To clear cache
IMDBTraktSyncer --clear-cache

# To uninstall
IMDBTraktSyncer --uninstall

# To perform a clean uninstall
IMDBTraktSyncer --clean-uninstall

# To get the installation directory
IMDBTraktSyncer --directory

# Use multiple commands at once
IMDBTraktSyncer --clear-user-data --clear-cache
````