### PR TITLE
Fix for updating invalid Trakt API tokens

### DIFF
--- a/IMDBTraktSyncer/authTrakt.py
+++ b/IMDBTraktSyncer/authTrakt.py
@@ -27,8 +27,6 @@ def authenticate(client_id, client_secret, refresh_token=None):
 
         # Use make_trakt_request for the POST request
         response = EH.make_trakt_request('https://api.trakt.tv/oauth/token', headers=headers, payload=data)
-        if response is None:
-            raise Exception("Failed to authenticate. Please check your credentials.")
 
         if response:
             json_data = response.json()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), 'r', encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '3.1.2'
+VERSION = '3.1.3'
 DESCRIPTION = 'A python script that syncs user watchlist, ratings and reviews for Movies, TV Shows and Episodes both ways between Trakt and IMDB.'
 
 # Setting up


### PR DESCRIPTION
Fixes a new issue where invalid Trakt API tokens did not re-prompt the user to re-authenticate, causing the script to fail.