### PR TITLE
Fixes for several pathing issues on linux and macos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "IMDBTraktSyncer"
-version = "3.2.2"
+version = "3.2.3"
 description = "A python script that syncs user watchlist, ratings and reviews for Movies, TV Shows and Episodes both ways between Trakt and IMDB."
 authors = [
     {name = "RileyXX"}


### PR DESCRIPTION
- Fixes https://github.com/RileyXX/IMDB-Trakt-Syncer/issues/132 moving the extracted chrome directory was causing the script to fail.
- Fixes [#issuecomment-2594902045](https://github.com/RileyXX/IMDB-Trakt-Syncer/issues/132#issuecomment-2594902045) and [#issuecomment-2595089014](https://github.com/RileyXX/IMDB-Trakt-Syncer/issues/132#issuecomment-2595089014) where the extracted Chrome binary was not in the expected directory. And fixes macos/linux comparability when clearing the selenium chromedriver cache.