### PR TITLE
Fix chromedriver permissions issue on macos and linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "IMDBTraktSyncer"
-version = "3.2.5"
+version = "3.2.7"
 description = "A python script that syncs user watchlist, ratings and reviews for Movies, TV Shows and Episodes both ways between Trakt and IMDB."
 authors = [
     {name = "RileyXX"}


### PR DESCRIPTION
Potential fix for permissions issue on macos and linux for extracted chromedriver binary where the user does not have the proper read/write/execution permissions