### PR TITLE
Improve logic when comparing items with outdated IMDB ID + improve driver handling

### DIFF
--- a/IMDBTraktSyncer/arguments.py
+++ b/IMDBTraktSyncer/arguments.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 import os
 import platform
+import stat
 
 def try_remove(file_path, retries=3, delay=1):
     """
@@ -121,26 +122,31 @@ def clear_selenium_manager_cache():
 
 def clear_user_data(main_directory):
     """
-    Deletes the credentials.txt file in the given directory.
-    
-    :param main_directory: Directory path where credentials.txt should be deleted.
+    Deletes the credentials.txt file and Chrome user data directories under the given main directory.
+
+    :param main_directory: Directory path where credentials.txt and user data should be deleted.
     """
     credentials_path = os.path.join(main_directory, "credentials.txt")
-    
-    # Check if the credentials.txt file exists
-    if not os.path.exists(credentials_path):
-        print(f"Error: {credentials_path} does not exist.")
-        return
-    
-    try:
+
+    if os.path.exists(credentials_path):
         # Remove the credentials.txt file
-        os.remove(credentials_path)
-        print(f"Removed {credentials_path}")
-    except PermissionError as e:
-        print(f"Permission error removing {credentials_path}: {e}")
-    except Exception as e:
-        print(f"Error removing {credentials_path}: {e}")
+        try_remove(credentials_path)
+
+    # Construct the Chrome user data directory path dynamically
+    chrome_directory = os.path.join(main_directory, "Chrome")
+    user_data_found = False
     
+    if os.path.exists(chrome_directory):
+        for root, dirs, files in os.walk(chrome_directory):
+            for dir_name in dirs:
+                if dir_name == "userData":
+                    user_data_directory = os.path.join(root, dir_name)
+                    user_data_found = True
+                    break
+        
+    if user_data_found:
+        try_remove(user_data_directory)
+
     print("Clear user data complete.")
 
 def clear_cache(main_directory):

--- a/IMDBTraktSyncer/checkChrome.py
+++ b/IMDBTraktSyncer/checkChrome.py
@@ -14,11 +14,21 @@ from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.chrome.options import Options
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from IMDBTraktSyncer import errorHandling as EH
-from IMDBTraktSyncer import errorLogger as EL
 
 def get_main_directory():
     directory = os.path.dirname(os.path.realpath(__file__))
     return directory
+    
+def get_browser_type():
+    # Change browser type
+    # Valid options: "chrome" or "chrome-headless-shell"
+    browser_type = "chrome"
+    
+    # Run headless setting
+    # Valid options: True or False
+    headless = True
+    
+    return browser_type, headless
 
 def try_remove(file_path, retries=3, delay=1):
     """
@@ -257,7 +267,7 @@ def is_chromedriver_up_to_date(main_directory, current_version):
     print(f"Chromedriver binary not found under {chromedriver_dir}.")
     return False
 
-def download_and_extract_chrome(download_url, main_directory, version, max_wait_time=30, wait_interval=5):
+def download_and_extract_chrome(download_url, main_directory, version, max_wait_time=300, wait_interval=5):
     temp_dir = tempfile.gettempdir()  # Use a temporary directory for the download
     temp_zip_path = Path(temp_dir) / f"chrome-{version}.zip"
     zip_path = Path(main_directory) / f"chrome-{version}.zip"
@@ -339,7 +349,7 @@ def download_and_extract_chrome(download_url, main_directory, version, max_wait_
 
     return extract_path
     
-def download_and_extract_chromedriver(download_url, main_directory, version, max_wait_time=30, wait_interval=5):
+def download_and_extract_chromedriver(download_url, main_directory, version, max_wait_time=300, wait_interval=5):
     temp_dir = tempfile.gettempdir()  # Use a temporary directory for the download
     temp_zip_path = Path(temp_dir) / f"chromedriver-{version}.zip"
     zip_path = Path(main_directory) / f"chromedriver-{version}.zip"
@@ -631,8 +641,7 @@ def clear_selenium_manager_cache():
 def checkChrome():
     main_directory = get_main_directory()
     
-    browser_type = "chrome"
-    #browser_type = "chrome-headless-shell"
+    browser_type, _ = get_browser_type()
 
     # Get latest version details
     latest_version = get_latest_stable_version()

--- a/IMDBTraktSyncer/checkVersion.py
+++ b/IMDBTraktSyncer/checkVersion.py
@@ -15,7 +15,7 @@ def get_installed_version():
             if line.startswith("Version:"):
                 return line.split()[1]
     except subprocess.CalledProcessError as e:
-        print(f"Error: Could not retrieve python version using '{sys.executable} -m pip': {e}")
+        print(f"Error: Could not retrieve IMDBTraktSyncer version using '{sys.executable} -m pip': {e}")
     except FileNotFoundError:
         print(f"Error: Python executable '{sys.executable}' does not have pip installed.")
 

--- a/IMDBTraktSyncer/imdbData.py
+++ b/IMDBTraktSyncer/imdbData.py
@@ -27,7 +27,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
     
     
     # Generate watchlist export
-    success, status_code, url, driver = EH.get_page_with_retries('https://www.imdb.com/list/watchlist', driver, wait)
+    success, status_code, url, driver, wait = EH.get_page_with_retries('https://www.imdb.com/list/watchlist', driver, wait)
     if not success:
         # Page failed to load, raise an exception
         raise PageLoadException(f"Failed to load page. Status code: {status_code}. URL: {url}")
@@ -37,7 +37,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
     time.sleep(3)
     
     # Generate ratings export
-    success, status_code, url, driver = EH.get_page_with_retries('https://www.imdb.com/list/ratings', driver, wait)
+    success, status_code, url, driver, wait = EH.get_page_with_retries('https://www.imdb.com/list/ratings', driver, wait)
     if not success:
         # Page failed to load, raise an exception
         raise PageLoadException(f"Failed to load page. Status code: {status_code}. URL: {url}")
@@ -59,7 +59,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
 
     while time.time() - start_time < max_wait_time:
         # Wait for export processing to finish
-        success, status_code, url, driver = EH.get_page_with_retries('https://www.imdb.com/exports/', driver, wait)
+        success, status_code, url, driver, wait = EH.get_page_with_retries('https://www.imdb.com/exports/', driver, wait)
         if not success:
             # Page failed to load, raise an exception
             raise PageLoadException(f"Failed to load page. Status code: {status_code}. URL: {url}")
@@ -80,7 +80,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
     #Get IMDB Watchlist Items
     try:
         # Load page
-        success, status_code, url, driver = EH.get_page_with_retries('https://www.imdb.com/exports/', driver, wait)
+        success, status_code, url, driver, wait = EH.get_page_with_retries('https://www.imdb.com/exports/', driver, wait)
         if not success:
             # Page failed to load, raise an exception
             raise PageLoadException(f"Failed to load page. Status code: {status_code}. URL: {url}")
@@ -142,6 +142,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
                 for row in reader:
                     title = row[header_index['Title']]
                     year = row[header_index['Year']]
+                    year = int(year) if year else None
                     imdb_id = row[header_index['Const']]
                     date_added = row[header_index['Created']]
                     media_type = row[header_index['Title Type']]
@@ -182,7 +183,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
     # Get IMDB Ratings
     try:
         # Load page
-        success, status_code, url, driver = EH.get_page_with_retries('https://www.imdb.com/exports/', driver, wait)
+        success, status_code, url, driver, wait = EH.get_page_with_retries('https://www.imdb.com/exports/', driver, wait)
         if not success:
             # Page failed to load, raise an exception
             raise PageLoadException(f"Failed to load page. Status code: {status_code}. URL: {url}")
@@ -244,6 +245,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
                 for row in reader:
                         title = row[header_index['Title']]
                         year = row[header_index['Year']]
+                        year = int(year) if year else None
                         rating = row[header_index['Your Rating']]
                         imdb_id = row[header_index['Const']]
                         date_added = row[header_index['Date Rated']]
@@ -299,7 +301,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
     #Get IMDB Reviews
     
     # Load page
-    success, status_code, url, driver = EH.get_page_with_retries('https://www.imdb.com/profile', driver, wait)
+    success, status_code, url, driver, wait = EH.get_page_with_retries('https://www.imdb.com/profile', driver, wait)
     if not success:
         # Page failed to load, raise an exception
         raise PageLoadException(f"Failed to load page. Status code: {status_code}. URL: {url}")
@@ -314,7 +316,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
         reviews_url = driver.current_url + "reviews/"
         
         # Load page
-        success, status_code, url, driver = EH.get_page_with_retries(reviews_url, driver, wait)
+        success, status_code, url, driver, wait = EH.get_page_with_retries(reviews_url, driver, wait)
         if not success:
             # Page failed to load, raise an exception
             raise PageLoadException(f"Failed to load page. Status code: {status_code}. URL: {url}")
@@ -334,6 +336,7 @@ def getImdbData(imdb_username, imdb_password, driver, directory, wait):
                     # Extract review details
                     review['Title'] = element.find_element(By.CSS_SELECTOR, ".lister-item-header a").text
                     review['Year'] = element.find_element(By.CSS_SELECTOR, ".lister-item-header span").text.strip('()').split('–')[0].strip()
+                    review['Year'] = int(year) if year else None
                     review['IMDB_ID'] = element.find_element(By.CSS_SELECTOR, ".lister-item-header a").get_attribute("href").split('/')[4]
                     review['IMDBReviewID'] = element.get_attribute("data-review-id")
                     review['Comment'] = element.find_element(By.CSS_SELECTOR, ".content > .text").text.strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "IMDBTraktSyncer"
-version = "3.3.0"
+version = "3.3.1"
 description = "A python script that syncs user watchlist, ratings and reviews for Movies, TV Shows and Episodes both ways between Trakt and IMDB."
 authors = [
     {name = "RileyXX"}


### PR DESCRIPTION
- Ignore processing items with matching Title, Year and Type, AND have non-matching IMDB IDs. This is to prevent outdated IMDB IDs from Trakt interfering with the comparison logic. This prevents the script from failing to process the same items on each run.
- Improve driver handling, passing both the driver and wait variables and returning them from the get_page_with_retries function to avoid driver instance mismatches and other related errors.