### PR TITLE
IMDB watchlist and IMDB watch history size limits don't account for unknown items

### DIFF
--- a/IMDBTraktSyncer/IMDBTraktSyncer.py
+++ b/IMDBTraktSyncer/IMDBTraktSyncer.py
@@ -276,22 +276,22 @@ def main():
             driver, wait = imdbData.generate_imdb_exports(driver, wait, directory, sync_watchlist_value, sync_ratings_value, sync_watch_history_value, remove_watched_from_watchlists_value, mark_rated_as_watched_value)
             driver, wait = imdbData.download_imdb_exports(driver, wait, directory, sync_watchlist_value, sync_ratings_value, sync_watch_history_value, remove_watched_from_watchlists_value, mark_rated_as_watched_value)
             if sync_watchlist_value or remove_watched_from_watchlists_value:
-                imdb_watchlist, driver, wait = imdbData.get_imdb_watchlist(driver, wait, directory)
+                imdb_watchlist, imdb_watchlist_size, driver, wait = imdbData.get_imdb_watchlist(driver, wait, directory)
             if sync_ratings_value or mark_rated_as_watched_value:
                 imdb_ratings, driver, wait = imdbData.get_imdb_ratings(driver, wait, directory)
             if sync_reviews_value:
                 imdb_reviews, errors_found_getting_imdb_reviews, driver, wait = imdbData.get_imdb_reviews(driver, wait, directory)
             if sync_watch_history_value or remove_watched_from_watchlists_value or mark_rated_as_watched_value:
-                imdb_watch_history, driver, wait = imdbData.get_imdb_checkins(driver, wait, directory)
+                imdb_watch_history, imdb_watch_history_size, driver, wait = imdbData.get_imdb_checkins(driver, wait, directory)
             print('Processing IMDB Data Complete')
                         
             if sync_watchlist_value:
                 # Check if IMDB watchlist has reached the 10,000 item limit. If limit is reached, disable syncing watchlists.
-                imdb_watchlist_limit_reached = EH.check_if_watchlist_limit_reached(imdb_watchlist)
+                imdb_watchlist_limit_reached = EH.check_if_watchlist_limit_reached(imdb_watchlist_size)
                               
             if sync_watch_history_value or mark_rated_as_watched_value:
                 # Check if IMDB watch history has reached the 10,000 item limit. If limit is reached, disable syncing watch history.
-                imdb_watch_history_limit_reached = EH.check_if_watch_history_limit_reached(imdb_watch_history)
+                imdb_watch_history_limit_reached = EH.check_if_watch_history_limit_reached(imdb_watch_history_size)
             
             # Remove duplicates from Trakt watch_history
             trakt_watch_history = EH.remove_duplicates_by_imdb_id(trakt_watch_history)

--- a/IMDBTraktSyncer/errorHandling.py
+++ b/IMDBTraktSyncer/errorHandling.py
@@ -580,14 +580,14 @@ def get_items_older_than_x_days(items, days):
 
     return [item for item in items if is_older(item)]
     
-def check_if_watch_history_limit_reached(list):
+def check_if_watch_history_limit_reached(size):
     """
-    Checks if the list has 10,000 or more items.
+    Checks if the watch history has 10,000 or more items.
     If true, updates the sync_watch_history in credentials.txt to False
     and marks the watch history limit as reached.
     
     Args:
-        list (list): List of the user's watch history.
+        size (int): Size of the user's watch history.
     
     Returns:
         bool: True if the watch history limit has been reached, False otherwise.
@@ -609,7 +609,7 @@ def check_if_watch_history_limit_reached(list):
     '''
 
     # Check if list has 10,000 or more items
-    if len(list) >= 9999:
+    if size >= 9999:
         '''
         # Update sync_watch_history to False
         credentials['sync_watch_history'] = False
@@ -632,14 +632,14 @@ def check_if_watch_history_limit_reached(list):
     # Return False if the limit hasn't been reached
     return False
     
-def check_if_watchlist_limit_reached(list):
+def check_if_watchlist_limit_reached(size):
     """
-    Checks if the list has 10,000 or more items.
+    Checks if the watchlist is 10,000 or more items.
     If true, updates the sync_watchlist in credentials.txt to False
     and marks the watchlist limit as reached.
     
     Args:
-        list (list): List of the user's watchlist.
+        size (int): Size of the user's watchlist.
     
     Returns:
         bool: True if the watchlist limit has been reached, False otherwise.
@@ -658,7 +658,7 @@ def check_if_watchlist_limit_reached(list):
         return False  # Return False if the file doesn't exist
 
     # Check if list has 10,000 or more items
-    if len(list) >= 9999:
+    if size >= 9999:
         # Update sync_watchlist to False
         credentials['sync_watchlist'] = False
         

--- a/IMDBTraktSyncer/imdbData.py
+++ b/IMDBTraktSyncer/imdbData.py
@@ -193,7 +193,9 @@ def get_imdb_watchlist(driver, wait, directory):
             if missing_columns:
                 raise ValueError(f"Required columns missing from CSV file: {', '.join(missing_columns)}")
 
+            imdb_watchlist_size = 0
             for row in reader:
+                imdb_watchlist_size += 1
                 title = row[header_index['Title']]
                 year = row[header_index['Year']]
                 year = int(year) if year else None
@@ -233,9 +235,9 @@ def get_imdb_watchlist(driver, wait, directory):
     except (NoSuchElementException, TimeoutException):
         # No IMDB Watchlist Items
         imdb_watchlist = []
-        pass
+        imdb_watchlist_size = 0
     
-    return imdb_watchlist, driver, wait
+    return imdb_watchlist, imdb_watchlist_size, driver, wait
 
 def get_imdb_ratings(driver, wait, directory):
     # Get IMDB Ratings
@@ -334,7 +336,9 @@ def get_imdb_checkins(driver, wait, directory):
             if missing_columns:
                 raise ValueError(f"Required columns missing from CSV file: {', '.join(missing_columns)}")
 
+            imdb_checkins_size = 0
             for row in reader:
+                imdb_checkins_size += 1
                 title = row[header_index['Title']]
                 year = row[header_index['Year']]
                 year = int(year) if year else None
@@ -375,9 +379,9 @@ def get_imdb_checkins(driver, wait, directory):
     except (NoSuchElementException, TimeoutException):
         # No IMDB Check-in Items
         imdb_checkins = []
-        pass
+        imdb_checkins_size = 0
     
-    return imdb_checkins, driver, wait
+    return imdb_checkins, imdb_checkins_size, driver, wait
             
 def get_media_type(imdb_id):
     url = f"https://api.trakt.tv/search/imdb/{imdb_id}"


### PR DESCRIPTION
Only entries that are in known categories count towards the size, so watchlist and watch history population will happen even if the size of the checkins/watchlist are already at 10,000.