### PR TITLE
Fixed an issue where TraktID was not found when removing watchlist items

### DIFF
--- a/IMDBTraktSyncer/IMDBTraktSyncer.py
+++ b/IMDBTraktSyncer/IMDBTraktSyncer.py
@@ -937,7 +937,7 @@ def main():
                             data = {
                                 "shows": [{
                                     "ids": {
-                                        "trakt": item["TraktID"]
+                                        "imdb": item["IMDB_ID"]
                                     }
                                 }]
                             }
@@ -946,7 +946,7 @@ def main():
                             data = {
                                 "movies": [{
                                     "ids": {
-                                        "trakt": item["TraktID"]
+                                        "imdb": item["IMDB_ID"]
                                     }
                                 }]
                             }
@@ -956,7 +956,7 @@ def main():
                             data = {
                                 "episodes": [{
                                     "ids": {
-                                        "trakt": item["TraktID"]
+                                        "imdb": item["IMDB_ID"]
                                     }
                                 }]
                             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "IMDBTraktSyncer"
-version = "3.4.5"
+version = "3.4.6"
 description = "A python script that syncs user watchlist, ratings, reviews and watch history for Movies, TV Shows and Episodes both ways between Trakt and IMDB."
 authors = [
     {name = "RileyXX"}


### PR DESCRIPTION
Fixed an issue where sometimes `TraktID` was not found when removing watchlist items, due to items from IMDB watchlist or IMDB watch history not having the `TraktID` key. Now uses IMDB_ID instead for removing watchlist items from Trakt.