### PR TITLE
Address new OAuth Trakt access_token expiration changes

### DIFF
--- a/IMDBTraktSyncer/checkChrome.py
+++ b/IMDBTraktSyncer/checkChrome.py
@@ -266,160 +266,192 @@ def is_chromedriver_up_to_date(main_directory, current_version):
     print(f"Chromedriver binary not found under {chromedriver_dir}.")
     return False
 
-def download_and_extract_chrome(download_url, main_directory, version, max_wait_time=300, wait_interval=60):
+def download_and_extract_chrome(download_url, main_directory, version, max_wait_time=300, wait_interval=60, max_retries=3):
     zip_path = Path(main_directory) / f"chrome-{version}.zip"
     extract_path = Path(main_directory) / "Chrome" / version
 
     # Ensure the main directory exists
     Path(main_directory).mkdir(parents=True, exist_ok=True)
 
-    try:
-        # Download the zip file directly to the main directory
-        response = EH.make_request_with_retries(download_url, stream=True)
-        response.raise_for_status()
-
-        # Get the expected file size from the response headers (if available)
-        expected_file_size = int(response.headers.get('Content-Length', 0))
-        print(f" - Expected file size: {expected_file_size} bytes")
-
-        # Write the zip file to the final location
-        with open(zip_path, "wb") as zip_file:
-            for chunk in response.iter_content(chunk_size=8192):
-                zip_file.write(chunk)
-
-        # Final wait to ensure the download is complete before extracting
-        time.sleep(wait_interval)
-        
-        # Validate the downloaded file size
-        actual_file_size = zip_path.stat().st_size
-        print(f" - Downloaded file size: {actual_file_size} bytes")
-
-        if expected_file_size and actual_file_size != expected_file_size:
-            raise RuntimeError(f" - Downloaded file size mismatch: expected {expected_file_size} bytes, got {actual_file_size} bytes")
-
-        # Verify the integrity of the ZIP file before extraction
-        if not zipfile.is_zipfile(zip_path):
-            raise RuntimeError(f" - The downloaded file is not a valid ZIP archive: {zip_path}")
-
-        # Extract the zip file
-        with zipfile.ZipFile(zip_path, "r") as zip_ref:
-            zip_ref.extractall(extract_path)
-
-        print(f" - Extraction complete to: {extract_path}")
-        
-        # Remove read-only attribute from the extracted folder
-        grant_permissions(extract_path)
-
-    except Exception as e:
-        raise RuntimeError(f" - Failed to download or extract Chrome version {version}: {e}")
-
-    finally:
-        # Cleanup the ZIP file
+    retries = 0
+    while retries <= max_retries:
         try:
-            if zip_path.exists():
-                zip_path.unlink()
-                print(f" - File {zip_path} deleted.")
+            # Download the zip file directly to the main directory
+            response = EH.make_request_with_retries(download_url, stream=True)
+            response.raise_for_status()
 
-            # Remove any stray .zip files in the directory
-            for file in Path(main_directory).glob("*.zip"):
-                if "chrome-" in file.name.lower():
-                    try:
-                        file.unlink()
-                        print(f" - Deleted file: {file}")
-                    except Exception as e:
-                        print(f" - Failed to delete file {file}: {e}")
+            # Get the expected file size from the response headers (if available)
+            expected_file_size = int(response.headers.get('Content-Length', 0))
+            print(f" - Expected file size: {expected_file_size} bytes")
 
-        except PermissionError:
-            print(f" - Permission denied when trying to delete {zip_path}. Ensure no other process is using it.")
+            # Write the zip file to the final location
+            with open(zip_path, "wb") as zip_file:
+                for chunk in response.iter_content(chunk_size=8192):
+                    zip_file.write(chunk)
+
+            # Final wait to ensure the download is complete before extracting
+            time.sleep(wait_interval)
+            
+            # Validate the downloaded file size
+            actual_file_size = zip_path.stat().st_size
+            print(f" - Downloaded file size: {actual_file_size} bytes")
+
+            if expected_file_size and actual_file_size != expected_file_size:
+                raise RuntimeError(f" - Downloaded file size mismatch: expected {expected_file_size} bytes, got {actual_file_size} bytes")
+
+            # Verify the integrity of the ZIP file before extraction
+            if not zipfile.is_zipfile(zip_path):
+                raise RuntimeError(f" - The downloaded file is not a valid ZIP archive: {zip_path}")
+
+            # Extract the zip file
+            with zipfile.ZipFile(zip_path, "r") as zip_ref:
+                zip_ref.extractall(extract_path)
+
+            print(f" - Extraction complete to: {extract_path}")
+            
+            # Remove read-only attribute from the extracted folder
+            grant_permissions(extract_path)
+        
+            # Break the retry loop if successful
+            break
+
+        except (RequestException, RuntimeError, zipfile.BadZipFile) as e:
+            retries += 1
+            print(f" - Retry {retries}/{max_retries} due to error: {e}")
+            if retries > max_retries:
+                raise RuntimeError(f" - Failed to download or extract Chromedriver version {version} after {max_retries} retries: {e}")
+            time.sleep(wait_interval)  # Wait before retrying
+
         except Exception as e:
-            print(f" - Unexpected error while deleting {zip_path}: {e}")
+            retries += 1
+            print(f" - Unexpected error occurred: {e}. Retry {retries}/{max_retries}")
+            if retries > max_retries:
+                raise RuntimeError(f" - Failed to download or extract Chromedriver version {version} due to an unexpected error after {max_retries} retries: {e}")
+            time.sleep(wait_interval)  # Wait before retrying
+
+        finally:
+            # Cleanup the ZIP file
+            try:
+                if zip_path.exists():
+                    zip_path.unlink()
+                    print(f" - File {zip_path} deleted.")
+
+                # Remove any stray .zip files in the directory
+                for file in Path(main_directory).glob("*.zip"):
+                    if "chrome-" in file.name.lower():
+                        try:
+                            file.unlink()
+                            print(f" - Deleted file: {file}")
+                        except Exception as e:
+                            print(f" - Failed to delete file {file}: {e}")
+
+            except PermissionError:
+                print(f" - Permission denied when trying to delete {zip_path}. Ensure no other process is using it.")
+            except Exception as e:
+                print(f" - Unexpected error while deleting {zip_path}: {e}")
 
     return extract_path
     
-def download_and_extract_chromedriver(download_url, main_directory, version, max_wait_time=300, wait_interval=60):
+def download_and_extract_chromedriver(download_url, main_directory, version, max_wait_time=300, wait_interval=60, max_retries=3):
     zip_path = Path(main_directory) / f"chromedriver-{version}.zip"
     extract_path = Path(main_directory) / "Chromedriver" / version
 
     # Ensure the main directory exists
     Path(main_directory).mkdir(parents=True, exist_ok=True)
 
-    try:
-        # Download the zip file directly to the main directory
-        response = EH.make_request_with_retries(download_url, stream=True)
-        response.raise_for_status()
-
-        # Get the expected file size from the response headers (if available)
-        expected_file_size = int(response.headers.get('Content-Length', 0))
-        print(f" - Expected file size: {expected_file_size} bytes")
-
-        # Write the zip file to the final location
-        with open(zip_path, "wb") as zip_file:
-            for chunk in response.iter_content(chunk_size=8192):
-                zip_file.write(chunk)
-
-        # Final wait to ensure the download is complete before extracting
-        time.sleep(wait_interval)
-        
-        # Validate the downloaded file size
-        actual_file_size = zip_path.stat().st_size
-        print(f" - Downloaded file size: {actual_file_size} bytes")
-
-        if expected_file_size and actual_file_size != expected_file_size:
-            raise RuntimeError(f" - Downloaded file size mismatch: expected {expected_file_size} bytes, got {actual_file_size} bytes")
-
-        # Verify the integrity of the ZIP file before extraction
-        if not zipfile.is_zipfile(zip_path):
-            raise RuntimeError(f" - The downloaded file is not a valid ZIP archive: {zip_path}")
-
-        # Extract the zip file
-        with zipfile.ZipFile(zip_path, "r") as zip_ref:
-            zip_ref.extractall(extract_path)
-
-        print(f" - Extraction complete to: {extract_path}")
-        
-        # Remove read-only attribute from the extracted folder
-        grant_permissions(extract_path)
-
-    except Exception as e:
-        raise RuntimeError(f" - Failed to download or extract Chromedriver version {version}: {e}")
-
-    finally:
-        # Clean up extracted files (excluding the chromedriver executable)
+    retries = 0
+    while retries <= max_retries:
         try:
-            # Get the path to the extracted directory
-            chromedriver_dir = Path(extract_path)
+            # Download the zip file directly to the main directory
+            response = EH.make_request_with_retries(download_url, stream=True)
+            response.raise_for_status()
 
-            # Clean up all files except the chromedriver executable
-            if chromedriver_dir.exists():
-                for item in chromedriver_dir.iterdir():
-                    # Check if the item is a subfolder (assumed to be the one containing the binary files)
-                    if item.is_dir():
-                        subfolder = item
-                        # Now, clean up files inside the subfolder
-                        for sub_item in subfolder.iterdir():
-                            # Skip deleting chromedriver executable
-                            if sub_item.name.lower() in ["chromedriver.exe", "chromedriver"]:
-                                continue
-                            try_remove(sub_item)  # Remove other files
+            # Get the expected file size from the response headers (if available)
+            expected_file_size = int(response.headers.get('Content-Length', 0))
+            print(f" - Expected file size: {expected_file_size} bytes")
 
-            # Cleanup the ZIP file
-            if zip_path.exists():
-                zip_path.unlink()
-                print(f" - File {zip_path} deleted.")
+            # Write the zip file to the final location
+            with open(zip_path, "wb") as zip_file:
+                for chunk in response.iter_content(chunk_size=8192):
+                    zip_file.write(chunk)
 
-            # Remove any stray .zip files in the directory
-            for file in Path(main_directory).glob("*.zip"):
-                if "chromedriver-" in file.name.lower():
-                    try:
-                        file.unlink()
-                        print(f" - Deleted file: {file}")
-                    except Exception as e:
-                        print(f" - Failed to delete file {file}: {e}")
+            # Final wait to ensure the download is complete before extracting
+            time.sleep(wait_interval)
+            
+            # Validate the downloaded file size
+            actual_file_size = zip_path.stat().st_size
+            print(f" - Downloaded file size: {actual_file_size} bytes")
 
-        except PermissionError:
-            print(f" - Permission denied when trying to delete {zip_path}. Ensure no other process is using it.")
+            if expected_file_size and actual_file_size != expected_file_size:
+                raise RuntimeError(f" - Downloaded file size mismatch: expected {expected_file_size} bytes, got {actual_file_size} bytes")
+
+            # Verify the integrity of the ZIP file before extraction
+            if not zipfile.is_zipfile(zip_path):
+                raise RuntimeError(f" - The downloaded file is not a valid ZIP archive: {zip_path}")
+
+            # Extract the zip file
+            with zipfile.ZipFile(zip_path, "r") as zip_ref:
+                zip_ref.extractall(extract_path)
+
+            print(f" - Extraction complete to: {extract_path}")
+            
+            # Remove read-only attribute from the extracted folder
+            grant_permissions(extract_path)
+            
+            # Break the retry loop if successful
+            break
+        
+        except (RequestException, RuntimeError, zipfile.BadZipFile) as e:
+            retries += 1
+            print(f" - Retry {retries}/{max_retries} due to error: {e}")
+            if retries > max_retries:
+                raise RuntimeError(f" - Failed to download or extract Chromedriver version {version} after {max_retries} retries: {e}")
+            time.sleep(wait_interval)  # Wait before retrying
+
         except Exception as e:
-            print(f" - Unexpected error while deleting {zip_path}: {e}")
+            retries += 1
+            print(f" - Unexpected error occurred: {e}. Retry {retries}/{max_retries}")
+            if retries > max_retries:
+                raise RuntimeError(f" - Failed to download or extract Chromedriver version {version} due to an unexpected error after {max_retries} retries: {e}")
+            time.sleep(wait_interval)  # Wait before retrying
+
+        finally:
+            # Clean up extracted files (excluding the chromedriver executable)
+            try:
+                # Get the path to the extracted directory
+                chromedriver_dir = Path(extract_path)
+
+                # Clean up all files except the chromedriver executable
+                if chromedriver_dir.exists():
+                    for item in chromedriver_dir.iterdir():
+                        # Check if the item is a subfolder (assumed to be the one containing the binary files)
+                        if item.is_dir():
+                            subfolder = item
+                            # Now, clean up files inside the subfolder
+                            for sub_item in subfolder.iterdir():
+                                # Skip deleting chromedriver executable
+                                if sub_item.name.lower() in ["chromedriver.exe", "chromedriver"]:
+                                    continue
+                                try_remove(sub_item)  # Remove other files
+
+                # Cleanup the ZIP file
+                if zip_path.exists():
+                    zip_path.unlink()
+                    print(f" - File {zip_path} deleted.")
+
+                # Remove any stray .zip files in the directory
+                for file in Path(main_directory).glob("*.zip"):
+                    if "chromedriver-" in file.name.lower():
+                        try:
+                            file.unlink()
+                            print(f" - Deleted file: {file}")
+                        except Exception as e:
+                            print(f" - Failed to delete file {file}: {e}")
+
+            except PermissionError:
+                print(f" - Permission denied when trying to delete {zip_path}. Ensure no other process is using it.")
+            except Exception as e:
+                print(f" - Unexpected error while deleting {zip_path}: {e}")
 
     return extract_path
 

--- a/IMDBTraktSyncer/verifyCredentials.py
+++ b/IMDBTraktSyncer/verifyCredentials.py
@@ -2,7 +2,7 @@ import os
 import json
 import sys
 import datetime
-from datetime import timedelta
+from datetime import timedelta, timezone
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from IMDBTraktSyncer import authTrakt
@@ -22,7 +22,7 @@ def prompt_get_credentials():
         "trakt_client_secret": "empty",
         "trakt_access_token": "empty",
         "trakt_refresh_token": "empty",
-        "last_trakt_token_refresh": "empty",
+        "trakt_token_expires": "empty",
         "imdb_username": "empty",
         "imdb_password": "empty"
     }
@@ -44,7 +44,7 @@ def prompt_get_credentials():
     
     # Prompt user for missing credentials, excluding tokens
     for key, value in values.items():
-        if value == "empty" and key not in ["trakt_access_token", "trakt_refresh_token", "last_trakt_token_refresh"]:
+        if value == "empty" and key not in ["trakt_access_token", "trakt_refresh_token", "trakt_token_expires"]:
             if key == "imdb_username":
                 prompt_message = f"Please enter a value for {key} (email or phone number): "
             elif key == "trakt_client_id":
@@ -61,32 +61,30 @@ def prompt_get_credentials():
             values[key] = input(prompt_message).strip()
 
     # Handle token refresh if necessary
-    last_trakt_token_refresh = values.get("last_trakt_token_refresh", "empty")
     should_refresh = True
-    if last_trakt_token_refresh != "empty":
+    trakt_token_expires = values.get("trakt_token_expires", "empty")
+    
+    if trakt_token_expires != "empty":
         try:
-            last_trakt_token_refresh_time = datetime.datetime.fromisoformat(last_trakt_token_refresh)
-            if datetime.datetime.now() - last_trakt_token_refresh_time < timedelta(days=7):
+            expiration_time = datetime.datetime.fromisoformat(trakt_token_expires).replace(tzinfo=timezone.utc)
+            if datetime.datetime.now(timezone.utc).replace(tzinfo=timezone.utc) < expiration_time:
                 should_refresh = False
         except ValueError:
-            pass  # Invalid date format, treat as refresh needed
-
+            pass  # Invalid date format, force refresh
+    
     if should_refresh:
-        trakt_access_token = None
-        trakt_refresh_token = None
         client_id = values["trakt_client_id"]
         client_secret = values["trakt_client_secret"]
+        refresh_token = values.get("trakt_refresh_token", "empty")
 
-        if "trakt_refresh_token" in values and values["trakt_refresh_token"] != "empty":
-            trakt_access_token = values["trakt_refresh_token"]
-            trakt_access_token, trakt_refresh_token = authTrakt.authenticate(client_id, client_secret, trakt_access_token)
+        if refresh_token != "empty":
+            access_token, refresh_token, expiration_time = authTrakt.authenticate(client_id, client_secret, refresh_token)
         else:
-            trakt_access_token, trakt_refresh_token = authTrakt.authenticate(client_id, client_secret)
-
-        # Update tokens and last refresh time
-        values["trakt_access_token"] = trakt_access_token
-        values["trakt_refresh_token"] = trakt_refresh_token
-        values["last_trakt_token_refresh"] = datetime.datetime.now().isoformat()
+            access_token, refresh_token, expiration_time = authTrakt.authenticate(client_id, client_secret)
+        
+        values["trakt_access_token"] = access_token
+        values["trakt_refresh_token"] = refresh_token
+        values["trakt_token_expires"] = expiration_time
 
     # Merge updated credentials back into the file data
     file_data.update(values)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "IMDBTraktSyncer"
-version = "3.4.7"
+version = "3.4.8"
 description = "A python script that syncs user watchlist, ratings, reviews and watch history for Movies, TV Shows and Episodes both ways between Trakt and IMDB."
 authors = [
     {name = "RileyXX"}


### PR DESCRIPTION
- Starting on March 4, 2025, the Trakt OAuth access_token expires in 24 hours, instead of 3 months. This pr addresses this new requirement by getting the `expires_in` value from the Trakt api when authenticating and storing it to check when the token should be refreshed.
- Fix time remaining issues for api request errors