### PR TITLE
Fix for ValueError when updating existing IMDB ratings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "IMDBTraktSyncer"
-version = "3.5.0"
+version = "3.5.1"
 description = "A python script that syncs user watchlist, ratings, reviews and watch history for Movies, TV Shows and Episodes both ways between Trakt and IMDB."
 authors = [
     {name = "RileyXX"}


### PR DESCRIPTION
- Fix for #174 fixes an issue where `ValueError` was raised when updating existing IMDB ratings causing the script to fail. The error was due to page layout changes where the rating element is loaded in dynamically, and required the use of `.get_attribute("textContent")` instead of `.text` in order to get the rating element text. Also added ValueError check so that if this section of code breaks in the future due to layout changes it won't cause the entire script to fail.