### PR TITLE
Fix TimeoutException error when attempting to sync with an empty IMDB account

### DIFF
--- a/IMDBTraktSyncer/imdbData.py
+++ b/IMDBTraktSyncer/imdbData.py
@@ -88,8 +88,12 @@ def generate_imdb_exports(driver, wait, directory, sync_watchlist_value, sync_ra
             # Page failed to load, raise an exception
             raise PageLoadException(f"Failed to load page. Status code: {status_code}. URL: {url}")
         
-        # Locate all elements with the selector
-        summary_items = wait.until(EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".ipc-metadata-list-summary-item")))
+        try:
+            # Locate all elements with the selector
+            summary_items = wait.until(EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".ipc-metadata-list-summary-item")))
+        except TimeoutException:
+            print("No items found when attempting to download IMDB exports. Assuming no IMDB watchlist, ratings or check-ins to download.")
+            break
 
         # Check if any summary item contains "in progress"
         if not check_in_progress(summary_items):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "IMDBTraktSyncer"
-version = "3.5.3"
+version = "3.5.4"
 description = "A python script that syncs user watchlist, ratings, reviews and watch history for Movies, TV Shows and Episodes both ways between Trakt and IMDB."
 authors = [
     {name = "RileyXX"}


### PR DESCRIPTION
- Fix for #178 fixes an issue where a TimeoutException error occurs when syincing with an empty IMDB account which has no ratings, watchlist or check-in items to download from the IMDB exports page