### PR TITLE
Fix for error when generating IMDB exports with empty IMDB account

### DIFF
--- a/IMDBTraktSyncer/imdbData.py
+++ b/IMDBTraktSyncer/imdbData.py
@@ -92,7 +92,7 @@ def generate_imdb_exports(driver, wait, directory, sync_watchlist_value, sync_ra
             # Locate all elements with the selector
             summary_items = wait.until(EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".ipc-metadata-list-summary-item")))
         except TimeoutException:
-            print("No items found when attempting to download IMDB exports. Assuming no IMDB watchlist, ratings or check-ins to download.")
+            print("No items found when attempting to generate IMDB exports. Assuming no IMDB watchlist, ratings or check-ins to download.")
             break
 
         # Check if any summary item contains "in progress"
@@ -136,8 +136,9 @@ def download_imdb_exports(driver, wait, directory, sync_watchlist_value, sync_ra
     # Locate all export blocks
     try:
         summary_items = wait.until(EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".ipc-metadata-list-summary-item")))
-    except Exception:
-        raise Exception("Failed to locate export summary items.")
+    except TimeoutException:
+        print("No items found when attempting to download IMDB exports. Assuming no IMDB watchlist, ratings or check-ins to download.")
+        return driver, wait
 
     # Helper function to find buttons for CSV downloads
     def find_button(item_text):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "IMDBTraktSyncer"
-version = "3.5.5"
+version = "3.5.6"
 description = "A python script that syncs user watchlist, ratings, reviews and watch history for Movies, TV Shows and Episodes both ways between Trakt and IMDB."
 authors = [
     {name = "RileyXX"}


### PR DESCRIPTION
- Fix for #180 fixes an Exception error when generating IMDB exports with empty IMDB account which has no ratings, watchlist or check-in items to generate from the IMDB exports page