### PR TITLE
Fix for syncing reviews

### DIFF
--- a/IMDBTraktSyncer/imdbData.py
+++ b/IMDBTraktSyncer/imdbData.py
@@ -490,8 +490,8 @@ def get_imdb_reviews(driver, wait, directory):
                     else:
                         review['Type'] = 'unknown'
 
-                    if review['Type'] != 'unknown':
-                        reviews.append(review)
+                    # if review['Type'] != 'unknown':
+                    reviews.append(review)
                     
                 try:
                     # Check if "Next" link exists
@@ -540,7 +540,7 @@ def get_imdb_reviews(driver, wait, directory):
         print(f"{error_message}")
         traceback.print_exc()
         EL.logger.error(error_message, exc_info=True)
-
+    
     # Filter out duplicate reviews for the same item based on ID
     filtered_reviews = []
     seen = set()

--- a/IMDBTraktSyncer/traktData.py
+++ b/IMDBTraktSyncer/traktData.py
@@ -125,9 +125,14 @@ def get_trakt_comments(encoded_username):
                 show_movie_or_episode_year = None
                 show_movie_or_episode_imdb_id = None
             else:
-                show_movie_or_episode_title = None
-                show_movie_or_episode_year = None
-                show_movie_or_episode_imdb_id = None
+                # Generic fallback for unknown types
+                # Find the first dict that has title/year/ids
+                for key, value in comment.items():
+                    if isinstance(value, dict) and "title" in value:
+                        show_movie_or_episode_title = value.get("title")
+                        show_movie_or_episode_year = value.get("year")
+                        show_movie_or_episode_imdb_id = remove_slashes(value.get("ids", {}).get("imdb"))
+                        break
 
             comment_info = comment['comment']
             trakt_comment_id = comment_info.get('id')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "IMDBTraktSyncer"
-version = "3.6.3"
+version = "3.6.4"
 description = "A python script that syncs user watchlist, ratings, reviews and watch history for Movies, TV Shows and Episodes both ways between Trakt and IMDB."
 authors = [
     {name = "RileyXX"}


### PR DESCRIPTION
- Fixed an issue where some IMDB reviews were omitted from comparison with Trakt reviews due to None Type attribute returned from Trakt api. This was causing some reviews to be resubmitted to IMDB.
- Fixed an issue where reviews resubmitted to IMDB that already have an existing review would duplicate the title and body fields, now it will clear the fields properly before submitting, and also skip submitting a review if one already exists (it shouldn't be resubmitting anything anyway unless there is issue upstream like the issue mentioned above)
- Added new filter for comparing trakt and imdb review lists to remove unknown types