### PR TITLE
Add support for running package as a module

### DIFF
--- a/IMDBTraktSyncer/__main__.py
+++ b/IMDBTraktSyncer/__main__.py
@@ -1,0 +1,4 @@
+from .IMDBTraktSyncer import main
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "IMDBTraktSyncer"
-version = "3.6.4"
+version = "3.6.5"
 description = "A python script that syncs user watchlist, ratings, reviews and watch history for Movies, TV Shows and Episodes both ways between Trakt and IMDB."
 authors = [
     {name = "RileyXX"}


### PR DESCRIPTION
- Added `__main__.py` to allow running the package as a module.
  - You can now run with:
    ```bash
    python -m IMDBTraktSyncer
    ```
  - Existing methods still work:
    - CLI command: `IMDBTraktSyncer`
    - Direct execution: `python IMDBTraktSyncer.py`
  - This change improves compatibility with Python module execution and makes it easier to run the syncer in environments where the script may not be on `PATH`.
