### PR TITLE
Add support for docker

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,11 +2,11 @@ name: Docker
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,69 @@
+name: Docker
+
+on:
+  push:
+    branches: ["master"]
+    # Publish semver tags as releases.
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: ["master"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # branch event
+            type=ref,enable=true,event=branch
+            # tag event
+            type=ref,enable=true,event=tag
+            # pull request event
+            type=ref,enable=true,prefix=pr-,suffix=,event=pr
+            # commit sha
+            type=sha,prefix=,suffix=,format=short
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM python:3.10-slim
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV APP_HOME /app
+ENV CONFIG_DIR /config
+ENV DOWNLOAD_DIR /app/downloads
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    # Chrome dependencies
+    libnss3 \
+    libnspr4 \
+    libdbus-1-3 \
+    libglib2.0-0 \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcups2 \
+    libdrm2 \
+    libgbm-dev \
+    libgtk-3-0 \
+    libxkbcommon-dev \
+    libxss1 \
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxrandr2 \
+    libdbus-glib-1-2 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR ${APP_HOME}
+
+COPY pyproject.toml .
+COPY IMDBTraktSyncer IMDBTraktSyncer
+COPY LICENSE .
+
+RUN pip install --no-cache-dir .
+
+CMD ["IMDBTraktSyncer"]

--- a/IMDBTraktSyncer/IMDBTraktSyncer.py
+++ b/IMDBTraktSyncer/IMDBTraktSyncer.py
@@ -15,6 +15,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from IMDBTraktSyncer import arguments
+from IMDBTraktSyncer.checkChrome import get_main_directory
 
 class PageLoadException(Exception):
     pass
@@ -64,7 +65,7 @@ def main():
         
         try:
             # Print credentials directory
-            VC.print_directory(main_directory)
+            VC.print_directory()
             
             # Get credentials
             _, _, _, _, imdb_username, imdb_password = VC.prompt_get_credentials()
@@ -81,13 +82,13 @@ def main():
             browser_type, headless = CC.get_browser_type()
 
             # Set up directory for downloads
-            directory = os.path.dirname(os.path.realpath(__file__))
+            directory = get_main_directory()
 
             # Start WebDriver
             print('Starting WebDriver...')
             
-            chrome_binary_path  = CC.get_chrome_binary_path(directory)
-            chromedriver_binary_path  = CC.get_chromedriver_binary_path(directory)
+            chrome_binary_path  = CC.get_chrome_binary_path()
+            chromedriver_binary_path  = CC.get_chromedriver_binary_path()
             user_data_directory = CC.get_user_data_directory()
             
             # Initialize Chrome options

--- a/IMDBTraktSyncer/arguments.py
+++ b/IMDBTraktSyncer/arguments.py
@@ -6,6 +6,8 @@ import os
 import platform
 import stat
 
+from IMDBTraktSyncer.verifyCredentials import get_credentials_file_path
+
 def try_remove(file_path, retries=3, delay=1):
     """
     Tries to remove a file or directory, retrying if it's in use or read-only.
@@ -126,7 +128,7 @@ def clear_user_data(main_directory):
 
     :param main_directory: Directory path where credentials.txt and user data should be deleted.
     """
-    credentials_path = os.path.join(main_directory, "credentials.txt")
+    credentials_path = get_credentials_file_path()
 
     if os.path.exists(credentials_path):
         # Remove the credentials.txt file

--- a/IMDBTraktSyncer/checkChrome.py
+++ b/IMDBTraktSyncer/checkChrome.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from IMDBTraktSyncer import errorHandling as EH
 
 def get_main_directory():
-    directory = os.path.dirname(os.path.realpath(__file__))
+    directory = os.environ.get("DOWNLOAD_DIR") or os.path.dirname(os.path.realpath(__file__))
     return directory
     
 def get_browser_type():
@@ -121,7 +121,7 @@ def grant_permissions(path: Path):
                 print(f"Error modifying permissions for {item_path}: {e}")
 
 def get_user_data_directory():
-    directory = os.path.dirname(os.path.realpath(__file__))  # Current script's directory
+    directory = get_main_directory()  # Current script's directory
     version = get_latest_stable_version()  # Assuming this function exists and returns a version string
 
     # Path to the version directory
@@ -496,7 +496,8 @@ def remove_old_versions(main_directory, latest_version, browser_type):
             print(f"Removing old Chromedriver version: {version_dir.name}...")
             try_remove(version_dir)
 
-def get_chrome_binary_path(main_directory):
+def get_chrome_binary_path():
+    main_directory = get_main_directory()
     version = get_latest_stable_version()
 
     # Build the path to the version directory
@@ -542,7 +543,8 @@ def get_chrome_binary_path(main_directory):
 
     raise FileNotFoundError(f"No valid Chrome binary found for platform {platform_key} in {chrome_dir}")
     
-def get_chromedriver_binary_path(main_directory):
+def get_chromedriver_binary_path():
+    main_directory = get_main_directory()
     version = get_latest_stable_version()
 
     chromedriver_dir = Path(main_directory) / "Chromedriver" / version

--- a/IMDBTraktSyncer/errorHandling.py
+++ b/IMDBTraktSyncer/errorHandling.py
@@ -661,8 +661,7 @@ def check_if_watch_history_limit_reached(size):
     
     '''
     # Define the file path for credentials.txt
-    here = os.path.abspath(os.path.dirname(__file__))
-    file_path = os.path.join(here, 'credentials.txt')
+    file_path = VC.get_credentials_file_path()
     
     # Load the credentials file
     credentials = {}
@@ -711,8 +710,7 @@ def check_if_watchlist_limit_reached(size):
         bool: True if the watchlist limit has been reached, False otherwise.
     """
     # Define the file path for credentials.txt
-    here = os.path.abspath(os.path.dirname(__file__))
-    file_path = os.path.join(here, 'credentials.txt')
+    file_path = VC.get_credentials_file_path()
     
     # Load the credentials file
     credentials = {}

--- a/IMDBTraktSyncer/verifyCredentials.py
+++ b/IMDBTraktSyncer/verifyCredentials.py
@@ -8,13 +8,19 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from IMDBTraktSyncer import authTrakt
 from IMDBTraktSyncer import errorLogger as EL
 
-def print_directory(main_directory):
-    print(f"Your settings are saved at:\n{main_directory}")
+def get_config_directory():
+    return os.environ.get("CONFIG_DIR") or os.path.abspath(os.path.dirname(__file__))
+
+def get_credentials_file_path():
+    here = get_config_directory()
+    return os.path.join(here, "credentials.txt")
+
+def print_directory():
+    print(f"Your settings are saved at:\n{get_config_directory()}\n")
 
 def prompt_get_credentials():
     # Define the file path
-    here = os.path.abspath(os.path.dirname(__file__))
-    file_path = os.path.join(here, 'credentials.txt')
+    file_path = get_credentials_file_path()
 
     # Default values for missing credentials
     default_values = {
@@ -101,8 +107,7 @@ def prompt_sync_ratings():
     Prompts the user to enable or disable syncing of ratings and updates the credentials file accordingly.
     """
     # Define the file path
-    here = os.path.abspath(os.path.dirname(__file__))
-    file_path = os.path.join(here, 'credentials.txt')
+    file_path = get_credentials_file_path()
 
     # Initialize credentials dictionary
     credentials = {}
@@ -149,8 +154,7 @@ def prompt_sync_watchlist():
     Reads and writes to the credentials file only when necessary.
     """
     # Define the file path
-    here = os.path.abspath(os.path.dirname(__file__))
-    file_path = os.path.join(here, 'credentials.txt')
+    file_path = get_credentials_file_path()
 
     # Load credentials file if it exists
     credentials = {}
@@ -182,7 +186,7 @@ def prompt_sync_watchlist():
     try:
         with open(file_path, 'w', encoding='utf-8') as file:
             json.dump(credentials, file, indent=4, separators=(', ', ': '))
-    except Exception as e:
+    except Exception:
         logging.error("Failed to write to credentials file.", exc_info=True)
         raise
 
@@ -195,8 +199,7 @@ def prompt_sync_watch_history():
     credentials file only when necessary.
     """
     # Define the file path
-    here = os.path.abspath(os.path.dirname(__file__))
-    file_path = os.path.join(here, 'credentials.txt')
+    file_path = get_credentials_file_path()
 
     # Load credentials file if it exists
     credentials = {}
@@ -243,8 +246,7 @@ def prompt_mark_rated_as_watched():
     credentials file only when necessary.
     """
     # Define the file path
-    here = os.path.abspath(os.path.dirname(__file__))
-    file_path = os.path.join(here, 'credentials.txt')
+    file_path = get_credentials_file_path()
 
     # Load credentials file if it exists
     credentials = {}
@@ -291,7 +293,7 @@ def check_imdb_reviews_last_submitted():
         bool: True if 240 hours have passed, otherwise False.
     """
     # Define file path
-    file_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'credentials.txt')
+    file_path = get_credentials_file_path()
 
     # Initialize default credentials
     credentials = {}
@@ -337,7 +339,7 @@ def prompt_sync_reviews():
         bool: True if user wants to sync reviews, False otherwise.
     """
     # Define the file path
-    file_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'credentials.txt')
+    file_path = get_credentials_file_path()
 
     # Attempt to read the sync_reviews value from the credentials file
     try:
@@ -384,8 +386,7 @@ def prompt_remove_watched_from_watchlists():
     Reads and updates the decision in a credentials file to avoid repeated prompting.
     """
     # Define the file path for credentials
-    here = os.path.abspath(os.path.dirname(__file__))
-    file_path = os.path.join(here, 'credentials.txt')
+    file_path = get_credentials_file_path()
 
     # Attempt to read the existing configuration
     try:
@@ -432,8 +433,7 @@ def prompt_remove_watchlist_items_older_than_x_days():
     Reads and updates the decision and the number of days in a credentials file to avoid repeated prompting.
     """
     # Define the file path for credentials
-    here = os.path.abspath(os.path.dirname(__file__))
-    file_path = os.path.join(here, 'credentials.txt')
+    file_path = get_credentials_file_path()
 
     # Attempt to read the existing configuration
     try:

--- a/README.md
+++ b/README.md
@@ -98,6 +98,23 @@ IMDBTraktSyncer --clear-user-data --clear-cache
 6. Follow the prompts during the first run. You will need to enter your Trakt `client ID` and `client secret` from step 3, as well as your IMDB `username` and `password`. Please note that these details are saved insecurely as `credentials.txt` in the same folder as the script. It is recommended to change your IMDB password to something unique beforehand.
 7. Setup is complete. The script will continue running and syncing your ratings. You can monitor its progress in the command line. See below for [setting up automation](https://github.com/RileyXX/IMDB-Trakt-Syncer#for-setting-up-automation-see-the-following-wiki-pages).
 
+## Docker Installation Method
+1. Install [Docker](https://www.docker.com/get-started/) and [Docker Compose](https://docs.docker.com/compose/install/) if not already installed.
+2. Create a `compose.yml` file with the following content:
+
+```yaml
+services:
+  imdb-trakt-syncer:
+    image: ghcr.io/rileyxx/imdb-trakt-syncer
+    volumes:
+      - ./data/config:/config
+      - ./data/downloads:/app/downloads
+```
+
+3. Run `docker compose run --rm imdb-trakt-syncer` and configure the script by following the prompts.
+4. Once configuration is complete, run `docker compose up -d imdb-trakt-syncer` to start the container in detached mode.
+5. To view logs, run `docker compose logs imdb-trakt-syncer`.
+
 ## For Setting Up Automation See the Following Wiki Pages:
 - Setup Automation for:
    - [Windows](https://github.com/RileyXX/IMDB-Trakt-Syncer/wiki/Setting-Up-Automation-on-Windows)

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,6 @@
+services:
+  imdbtraktsyncer:
+    build: .
+    volumes:
+      - ./data/config:/config
+      - ./data/downloads:/app/downloads


### PR DESCRIPTION
I added two new environment variables to be able to separate the config. Otherwise, everything is the same as before.

If somebody wants to test, it follow the instructions in the readme but replace the image url with `ghcr.io/c4illin/imdb-trakt-syncer:main`

Fixes #83